### PR TITLE
SDJwt parser language handling and fallback scenario

### DIFF
--- a/src/credential-parsers/SDJWTVCParser.test.ts
+++ b/src/credential-parsers/SDJWTVCParser.test.ts
@@ -78,4 +78,26 @@ describe("The SDJWTVCParser", () => {
 		assert(parsedCredential.value.signedClaims);
 
 	})
+
+	it("should default to the first metadata display when an invalid locale is passed", async () => {
+		const contextCopy = {...context, lang: 'el-GR'};
+		const parser = SDJWTVCParser({ httpClient: defaultHttpClient, context: contextCopy });
+		const parsedCredential = await parser.parse({ rawCredential });
+		let image;
+		if (parsedCredential.success) {
+			image = parsedCredential.value.metadata?.credential?.image?.dataUri;
+		}
+		assert(image);
+	});
+
+	it("should be able to match metadata display langs from 2 letter format", async () => {
+		const contextCopy = {...context, lang: 'en'};
+		const parser = SDJWTVCParser({ httpClient: defaultHttpClient, context: contextCopy });
+		const parsedCredential = await parser.parse({ rawCredential });
+		let image;
+		if (parsedCredential.success) {
+			image = parsedCredential.value.metadata?.credential?.image?.dataUri;
+		}
+		assert(image);
+	});
 })

--- a/src/credential-parsers/SDJWTVCParser.ts
+++ b/src/credential-parsers/SDJWTVCParser.ts
@@ -111,14 +111,28 @@ export function SDJWTVCParser(args: { context: Context, httpClient: HttpClient }
 
 				// Get localized display metadata from issuer metadata
 				const issuerDisplay = issuerMetadata?.credential_configurations_supported?.[credentialMetadata.vct]?.display;
-				const issuerDisplayLocalized = Array.isArray(issuerMetadata?.credential_configurations_supported?.[credentialMetadata.vct]?.display)
-					? issuerDisplay.find((d: any) => d.locale === args.context.lang)
-					: null;
+				let issuerDisplayLocalized = null;
+				if (Array.isArray(issuerDisplay)) {
+					const matchedDisplay = issuerDisplay.find((d: any) => d.locale === args.context.lang || d.locale.substring(0, 2) === args.context.lang);
+					if (matchedDisplay) {
+						issuerDisplayLocalized = matchedDisplay;
+					} else {
+						// select the first display as a fallback
+						issuerDisplayLocalized = issuerDisplay[0];
+					}
+				}
 
 				// Get localized display metadata from credential
-				const credentialDisplayLocalized = Array.isArray(credentialMetadata?.display)
-					? credentialMetadata.display.find((d: any) => d.lang === args.context.lang)
-					: null;
+				let credentialDisplayLocalized = null;
+				if (Array.isArray(credentialMetadata?.display)) {
+					const matchedDisplay = credentialMetadata.display.find((d: any) => d.lang === args.context.lang || d.lang.substring(0, 2) === args.context.lang);
+					if (matchedDisplay) {
+						credentialDisplayLocalized = matchedDisplay;
+					} else {
+						// select the first display as a fallback
+						credentialDisplayLocalized = credentialMetadata.display[0]
+					}
+				}
 
 				credentialFriendlyName = credentialDisplayLocalized?.name ?? null;
 


### PR DESCRIPTION
Added the following features to SDJWTParser:
* Match metadata languages even if they are passed with a 2 letter format (first to match the first two characters)
* Fallback to first metadata language if nothing matches