### PR TITLE
Use .strip() on SD-JWT VC TypeMetadata

### DIFF
--- a/src/schemas/SdJwtVcTypeMetadataSchema.ts
+++ b/src/schemas/SdJwtVcTypeMetadataSchema.ts
@@ -104,21 +104,23 @@ export const TypeMetadata = z.object({
 
 	// §7 integrity for the vct reference when used
 	["vct#integrity"]: IntegrityString.optional(),
-}).superRefine((val, ctx) => {
-	const ids = new Set<string>();
-	val.claims?.forEach((c, i) => {
-		if (c.svg_id) {
-			if (ids.has(c.svg_id)) {
-				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
-					message: `svg_id "${c.svg_id}" must be unique within the type metadata`,
-					path: ["claims", i, "svg_id"],
-				});
+})
+	.strip() // remove unknown fields but don't error
+	.superRefine((val, ctx) => {
+		const ids = new Set<string>();
+		val.claims?.forEach((c, i) => {
+			if (c.svg_id) {
+				if (ids.has(c.svg_id)) {
+					ctx.addIssue({
+						code: z.ZodIssueCode.custom,
+						message: `svg_id "${c.svg_id}" must be unique within the type metadata`,
+						path: ["claims", i, "svg_id"],
+					});
+				}
+				ids.add(c.svg_id);
 			}
-			ids.add(c.svg_id);
-		}
+		});
 	});
-});
 
 /** ---------- Exported Types ---------- */
 export type TypeMetadata = z.infer<typeof TypeMetadata>;


### PR DESCRIPTION
Switch TypeMetadata to .strip() so unknown fields are ignored instead of causing validation errors.
