### PR TITLE
Add x509_hash Client Identifier Prefix support

### DIFF
--- a/src/protocols/openid4vp/OpenID4VPClientAPI.test.ts
+++ b/src/protocols/openid4vp/OpenID4VPClientAPI.test.ts
@@ -98,6 +98,56 @@ describe("OpenID4VPClientAPI.generateAuthorizationRequestURL", () => {
 		assert(!("transaction_data" in payload));
 		assert(payload.client_metadata?.jwks?.keys?.length === 1);
 	});
+
+	it("should build a valid URL using x509_hash client identifier", async () => {
+		const kv = new MemoryStore<string, any>();
+		const httpClient: HttpClient = {
+			get: async () => {
+				throw new Error("unexpected http call");
+			}
+		};
+
+		const { privateKey } = await generateKeyPair("ES256");
+		const privateKeyPem = await exportPKCS8(privateKey);
+
+		const helper = new OpenID4VPClientAPI(
+			kv,
+			{
+				credentialEngineOptions: {
+					clockTolerance: 0,
+					subtle: crypto.subtle,
+					lang: "en",
+					trustedCertificates: [],
+					trustedCredentialIssuerIdentifiers: undefined
+				},
+				redirectUri: "openid4vp://cb"
+			},
+			httpClient
+		);
+
+		const certBytes = Uint8Array.from(Buffer.from(x5c[0], "base64"));
+		const certHash = await crypto.subtle.digest("SHA-256", certBytes);
+		const certHashB64Url = toBase64Url(new Uint8Array(certHash));
+		const expectedClientId = `x509_hash:${certHashB64Url}`;
+
+		const result = await helper.generateAuthorizationRequestURL(
+			presentationRequest,
+			"session-hash",
+			"https://verifier.example.com/cb",
+			"https://verifier.example.com",
+			privateKeyPem,
+			x5c,
+			OpenID4VPResponseMode.DIRECT_POST,
+			"https://verifier.example.com/callback",
+			"x509_hash"
+		);
+
+		assert(result.url.searchParams.get("client_id") === expectedClientId);
+		assert(result.rpState.audience === expectedClientId);
+		const [, encodedPayload] = result.rpState.signed_request.split(".");
+		const payload = JSON.parse(new TextDecoder().decode(fromBase64Url(encodedPayload)));
+		assert(payload.client_id === expectedClientId);
+	});
 });
 
 describe("OpenID4VPClientAPI small get/set helpers", () => {

--- a/src/protocols/openid4vp/OpenID4VPClientAPI.ts
+++ b/src/protocols/openid4vp/OpenID4VPClientAPI.ts
@@ -12,7 +12,7 @@ import { CredentialRenderingService } from "../../rendering";
 import { VerifiableCredentialFormat } from "../../types";
 import { fromBase64Url, toBase64Url } from "../../utils/util";
 import { TransactionData } from "./transactionData";
-import { CredentialEngineOptions, CredentialIssuerMetadata, IacasResponse, OpenID4VPOptions, PresentationClaims, PresentationInfo, OpenID4VPResponseMode, RPState } from "./types";
+import { CredentialEngineOptions, CredentialIssuerMetadata, IacasResponse, OpenID4VPClientIdScheme, OpenID4VPOptions, PresentationClaims, PresentationInfo, OpenID4VPResponseMode, RPState } from "./types";
 import { DcqlPresentationResult } from 'dcql';
 import { randomUUID } from "crypto";
 import { exportJWK, generateKeyPair, importPKCS8, SignJWT, compactDecrypt, CompactDecryptResult, importJWK } from "jose";
@@ -47,6 +47,25 @@ export class OpenID4VPClientAPI {
 		this.rpStateKV = kvStore;
 		this.options = options;
 		this.httpClient = httpClient;
+	}
+
+	private getBase64UrlSha256(data: Uint8Array): Promise<string> {
+		return this.options.credentialEngineOptions.subtle.digest("SHA-256", data).then((digest) => {
+			return toBase64Url(new Uint8Array(digest));
+		});
+	}
+
+	private decodeBase64Certificate(base64Certificate: string): Uint8Array {
+		if (typeof Buffer !== "undefined") {
+			return Uint8Array.from(Buffer.from(base64Certificate, "base64"));
+		}
+
+		const binary = atob(base64Certificate);
+		const bytes = new Uint8Array(binary.length);
+		for (let i = 0; i < binary.length; i++) {
+			bytes[i] = binary.charCodeAt(i);
+		}
+		return bytes;
 	}
 
 	private async initializeCredentialEngine() {
@@ -102,14 +121,33 @@ export class OpenID4VPClientAPI {
 			credentialRendering,
 		};
 }
-	async generateAuthorizationRequestURL(presentationRequest: any, sessionId: string, responseUri: string, baseUri: string, privateKeyPem: string, x5c: string[], responseMode: OpenID4VPResponseMode, callbackEndpoint?: string): Promise<{ url: URL; stateId: string; rpState: RPState }> {
+	async generateAuthorizationRequestURL(
+		presentationRequest: any,
+		sessionId: string,
+		responseUri: string,
+		baseUri: string,
+		privateKeyPem: string,
+		x5c: string[],
+		responseMode: OpenID4VPResponseMode,
+		callbackEndpoint?: string,
+		clientIdScheme: OpenID4VPClientIdScheme = "x509_san_dns",
+	): Promise<{ url: URL; stateId: string; rpState: RPState }> {
 
 		console.log("Presentation Request: Session id used for authz req ", sessionId);
 
 		const nonce = randomUUID();
 		const state = sessionId;
 
-		const client_id = new URL(responseUri).hostname
+		let clientIdWithoutPrefix;
+		switch (clientIdScheme) {
+			case "x509_hash":
+				const leafCertificate = x5c[0];
+				clientIdWithoutPrefix = await this.getBase64UrlSha256(this.decodeBase64Certificate(leafCertificate));
+				break;
+			case "x509_san_dns":
+				clientIdWithoutPrefix = new URL(responseUri).hostname;
+		}
+		const fullClientId = `${clientIdScheme}:${clientIdWithoutPrefix}`;
 
 		const [rsaImportedPrivateKey, rpEphemeralKeypair] = await Promise.all([
 			importPKCS8(privateKeyPem, 'ES256'),
@@ -145,7 +183,7 @@ export class OpenID4VPClientAPI {
 			response_uri: responseUri,
 			aud: "https://self-issued.me/v2",
 			iss: new URL(responseUri).hostname,
-			client_id: "x509_san_dns:" + client_id,
+			client_id: fullClientId,
 			response_type: "vp_token",
 			response_mode: responseMode,
 			state: state,
@@ -201,7 +239,7 @@ export class OpenID4VPClientAPI {
 
 			callback_endpoint: callbackEndpoint ?? null,
 
-			audience: `x509_san_dns:${client_id}`,
+			audience: fullClientId,
 			presentation_request_id:
 				presentationRequest.id ??
 				(presentationRequest.dcql_query as any)?.credentials?.[0]?.id,
@@ -237,7 +275,7 @@ export class OpenID4VPClientAPI {
 		const requestUri = baseUri + "/verification/request-object?id=" + state;
 
 		const redirectParameters = {
-			client_id: "x509_san_dns:" + client_id,
+			client_id: fullClientId,
 			request_uri: requestUri
 		};
 

--- a/src/protocols/openid4vp/OpenID4VPServerAPI.test.ts
+++ b/src/protocols/openid4vp/OpenID4VPServerAPI.test.ts
@@ -353,4 +353,52 @@ describe("OpenID4VPServerAPI.handleAuthorizationRequest", () => {
 		assert("error" in result);
 		assert(result.error === "old_state");
 	});
+
+	it("should accept x509_hash as supported client_id scheme", async () => {
+		const signedClaimsPid = { vct: "urn:eudi:pid:1", given_name: "Alice" };
+		const sdJwtPid = await buildSdJwt(signedClaimsPid);
+
+		const helper = new OpenID4VPServerAPI({
+			httpClient: { get: async () => { throw new Error("unexpected http call"); } },
+			rpStateStore: {
+				store: async () => {},
+				retrieve: async () => ({}) as any,
+			},
+			parseCredential: async () => ({ signedClaims: signedClaimsPid }),
+			selectCredentialForBatch: async () => null,
+			keystore: {
+				signJwtPresentation: async () => ({ vpjwt: "vp-jwt" }),
+				generateDeviceResponse: async () => ({ deviceResponseMDoc: {} }),
+			},
+			strings: {
+				purposeNotSpecified: "No purpose provided",
+				allClaimsRequested: "All claims",
+			},
+		});
+
+		const dcql_query = {
+			credentials: [
+				{
+					id: "testCredential",
+					format: VerifiableCredentialFormat.DC_SDJWT,
+					meta: { vct_values: ["urn:eudi:pid:1"] },
+					claims: [{ path: ["given_name"] }],
+				},
+			],
+		};
+
+		const url = new URL("openid4vp://authorize");
+		url.searchParams.set("client_id", "x509_hash:dummyhashvalue");
+		url.searchParams.set("response_uri", "https://verifier.example.com/cb");
+		url.searchParams.set("nonce", "nonce-hash");
+		url.searchParams.set("state", "state-hash");
+		url.searchParams.set("client_metadata", JSON.stringify({ vp_formats: {} }));
+		url.searchParams.set("response_mode", JSON.stringify(OpenID4VPResponseMode.DIRECT_POST));
+		url.searchParams.set("dcql_query", JSON.stringify(dcql_query));
+
+		const result = await helper.handleAuthorizationRequest(url.toString(), [
+			{ format: VerifiableCredentialFormat.DC_SDJWT, data: sdJwtPid, batchId: 7, instanceId: 0 },
+		]);
+		assert(!("error" in result));
+	});
 });

--- a/src/protocols/openid4vp/OpenID4VPServerAPI.test.ts
+++ b/src/protocols/openid4vp/OpenID4VPServerAPI.test.ts
@@ -4,6 +4,7 @@ import { Jwt, SDJwt } from "@sd-jwt/core";
 import { OpenID4VPServerAPI } from "./OpenID4VPServerAPI";
 import { OpenID4VPResponseMode } from "./types";
 import { VerifiableCredentialFormat } from "../../types";
+import { SignJWT, importPKCS8 } from "jose";
 
 const issuerSignedB64U = `omppc3N1ZXJBdXRohEOhASahGCGCWQJ4MIICdDCCAhugAwIBAgIBAjAKBggqhkjOPQQDAjCBiDELMAkGA1UEBhMCREUxDzANBgNVBAcMBkJlcmxpbjEdMBsGA1UECgwUQnVuZGVzZHJ1Y2tlcmVpIEdtYkgxETAPBgNVBAsMCFQgQ1MgSURFMTYwNAYDVQQDDC1TUFJJTkQgRnVua2UgRVVESSBXYWxsZXQgUHJvdG90eXBlIElzc3VpbmcgQ0EwHhcNMjQwNTMxMDgxMzE3WhcNMjUwNzA1MDgxMzE3WjBsMQswCQYDVQQGEwJERTEdMBsGA1UECgwUQnVuZGVzZHJ1Y2tlcmVpIEdtYkgxCjAIBgNVBAsMAUkxMjAwBgNVBAMMKVNQUklORCBGdW5rZSBFVURJIFdhbGxldCBQcm90b3R5cGUgSXNzdWVyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOFBq4YMKg4w5fTifsytwBuJf_7E7VhRPXiNm52S3q1ETIgBdXyDK3kVxGxgeHPivLP3uuMvS6iDEc7qMxmvduKOBkDCBjTAdBgNVHQ4EFgQUiPhCkLErDXPLW2_J0WVeghyw-mIwDAYDVR0TAQH_BAIwADAOBgNVHQ8BAf8EBAMCB4AwLQYDVR0RBCYwJIIiZGVtby5waWQtaXNzdWVyLmJ1bmRlc2RydWNrZXJlaS5kZTAfBgNVHSMEGDAWgBTUVhjAiTjoDliEGMl2Yr-ru8WQvjAKBggqhkjOPQQDAgNHADBEAiAbf5TzkcQzhfWoIoyi1VN7d8I9BsFKm1MWluRph2byGQIgKYkdrNf2xXPjVSbjW_U_5S5vAEC5XxcOanusOBroBbVZAn0wggJ5MIICIKADAgECAhQHkT1BVm2ZRhwO0KMoH8fdVC_vaDAKBggqhkjOPQQDAjCBiDELMAkGA1UEBhMCREUxDzANBgNVBAcMBkJlcmxpbjEdMBsGA1UECgwUQnVuZGVzZHJ1Y2tlcmVpIEdtYkgxETAPBgNVBAsMCFQgQ1MgSURFMTYwNAYDVQQDDC1TUFJJTkQgRnVua2UgRVVESSBXYWxsZXQgUHJvdG90eXBlIElzc3VpbmcgQ0EwHhcNMjQwNTMxMDY0ODA5WhcNMzQwNTI5MDY0ODA5WjCBiDELMAkGA1UEBhMCREUxDzANBgNVBAcMBkJlcmxpbjEdMBsGA1UECgwUQnVuZGVzZHJ1Y2tlcmVpIEdtYkgxETAPBgNVBAsMCFQgQ1MgSURFMTYwNAYDVQQDDC1TUFJJTkQgRnVua2UgRVVESSBXYWxsZXQgUHJvdG90eXBlIElzc3VpbmcgQ0EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARgbN3AUOdzv4qfmJsC8I4zyR7vtVDGp8xzBkvwhogD5YJE5wJ-Zj-CIf3aoyu7mn-TI6K8TREL8ht0w428OhTJo2YwZDAdBgNVHQ4EFgQU1FYYwIk46A5YhBjJdmK_q7vFkL4wHwYDVR0jBBgwFoAU1FYYwIk46A5YhBjJdmK_q7vFkL4wEgYDVR0TAQH_BAgwBgEB_wIBADAOBgNVHQ8BAf8EBAMCAYYwCgYIKoZIzj0EAwIDRwAwRAIgYSbvCRkoe39q1vgx0WddbrKufAxRPa7XfqB22XXRjqECIG5MWq9Vi2HWtvHMI_TFZkeZAr2RXLGfwY99fbsQjPOzWQS62BhZBLWnZnN0YXR1c6Frc3RhdHVzX2xpc3SiY2lkeBhsY3VyaXhWaHR0cHM6Ly9kZW1vLnBpZC1pc3N1ZXIuYnVuZGVzZHJ1Y2tlcmVpLmRlL3N0YXR1cy84ODc5M2MwMy0xNmFkLTQ0NjgtYmVmNy1jMDgzZDM4YWUyMTlnZG9jVHlwZXdldS5ldXJvcGEuZWMuZXVkaS5waWQuMWd2ZXJzaW9uYzEuMGx2YWxpZGl0eUluZm-jZnNpZ25lZMB0MjAyNS0wMi0xOFQxNDoxMjowNFppdmFsaWRGcm9twHQyMDI1LTAyLTE4VDE0OjEyOjA0Wmp2YWxpZFVudGlswHQyMDI1LTAzLTA0VDE0OjEyOjA0Wmx2YWx1ZURpZ2VzdHOhd2V1LmV1cm9wYS5lYy5ldWRpLnBpZC4xtgBYIKuGxnFMGhNio5-VUJKePlkmw33mloMA9fgqUR0ynOoJAVggWxNyUrVxTPW2riSGxx_U_irluD-vcJIOGGrafGo6JpwCWCDKOCdlxlbeX7mztFkzrM7MsZHs3gEyrmC79X3N2VpxkgNYICmI6iaQPBePM7fzBXqPyX5Gr-wNnWNCNb7wDUz4VDIRBFggfCuu8bFboi9BiRPsM447Ncg9A7K7A28iTEjVy9fmjBIFWCC6z1AlQM8ttJfuIQtPYlurlamh3MvAbSaQoUzAn-9L9gZYIKD1mVbZ5zb-_sp_E6vZCQ_U2QAQVNtbWAznR4xUm6LoB1ggWAn0OSPMM-m8NbgBZ-D6qLV0BEVeSnR4DIsUPUOZDbsIWCDyTDBH9XjK_JIq_W7d19UpmMq1pd1CjrmhfIHsctg3gwlYIK7ejRc3g-pfNGM0WHv4Oh1jfshl03Jvm3cxKHFnIIXmClggjPVDgZmiJEpnM6Zo_mzUQAbW5M6QZuRH43L6BqVeT7wLWCCSVNDu2CjnRkbC7_6m6-G6h8dTDWvlmGz0WD-MUCGERwxYIDpAXdFHgnACMgICXQpJi9nzBDRjsJ8bY1htM9GtgZlKDVggvhyWJk8WGQgokFghnd9DyZKyo8b6VrfAX8WTB0vH1QkOWCBLJFY_nbKL1x-5fbJCqS1IgEn_uMm9NJm2vqorCWwwPg9YIJIg7rTS_E3HAYjcjdV6WSpgZuXa8IKo7f5aC9ibPXQzEFggc_BlS8FdmjVtSqXrA2Xh58naoO0XdTbwclGo9itNTIERWCDzIo5muAIWaawEG69bUPG4mI4pEB5dUhadaUeMUEuwIhJYIEALsAqnwl3T1nC7YtOeDj-7OEHlmcwhCZjY2Qgsr2vCE1ggwG6In0GuGqO1isPXfh2EA7-mi18JAhfumCyQUA5FpYYUWCAL6kBisfFYUIU06t2d0UeqElM-c49VrVqfgYYSIx2JpRVYICYx93c95xCPFdhE03ZlReMnLGSjT_SJgEBMeErv0VlXbWRldmljZUtleUluZm-haWRldmljZUtleaQBAiABIVgganiJYJ0goJBbFzWZ52BDtTvTP1Fqb6k80C4UBl6JrFwiWCCWf2o4RIOTRI_UGubc0rCyIDo-o_LYRzYRnWzos3gcSm9kaWdlc3RBbGdvcml0aG1nU0hBLTI1NlhAcBP9-i1suGc_TnH7z4Mp8jFAz2Q__4w7Ju7dDG93XWfCE15E15WYaXUnkYY80tStLInk7nEi6IqEPHJPUyWiyGpuYW1lU3BhY2VzoXdldS5ldXJvcGEuZWMuZXVkaS5waWQuMZbYGFhRpGZyYW5kb21Q6lwO6tOJcjKhPDMrRPrRFGhkaWdlc3RJRABsZWxlbWVudFZhbHVlGDxxZWxlbWVudElkZW50aWZpZXJsYWdlX2luX3llYXJz2BhYT6RmcmFuZG9tUBwuvU0MGGbT2h94xazpeqloZGlnZXN0SUQBbGVsZW1lbnRWYWx1ZfVxZWxlbWVudElkZW50aWZpZXJrYWdlX292ZXJfMTLYGFhdpGZyYW5kb21Qo6kOsHqedb_9xHVlfCXHf2hkaWdlc3RJRAJsZWxlbWVudFZhbHVlZTUxMTQ3cWVsZW1lbnRJZGVudGlmaWVydHJlc2lkZW50X3Bvc3RhbF9jb2Rl2BhYVaRmcmFuZG9tUP6aK3BnaJ4ssYCnhgPSaZpoZGlnZXN0SUQDbGVsZW1lbnRWYWx1ZWZCRVJMSU5xZWxlbWVudElkZW50aWZpZXJrYmlydGhfcGxhY2XYGFhPpGZyYW5kb21QGR_ZD_ylLFjp_gFyoXxR0WhkaWdlc3RJRARsZWxlbWVudFZhbHVl9XFlbGVtZW50SWRlbnRpZmllcmthZ2Vfb3Zlcl8xNNgYWFWkZnJhbmRvbVByTlMf_mCOUvaECM5veox_aGRpZ2VzdElEBWxlbGVtZW50VmFsdWViREVxZWxlbWVudElkZW50aWZpZXJvaXNzdWluZ19jb3VudHJ52BhYY6RmcmFuZG9tUED3uH1EYolIFfAdQr8v6pVoZGlnZXN0SUQGbGVsZW1lbnRWYWx1ZcB0MTk2NC0wOC0xMlQwMDowMDowMFpxZWxlbWVudElkZW50aWZpZXJqYmlydGhfZGF0ZdgYWE-kZnJhbmRvbVBucDIRMDGt1bMXZVQopw3OaGRpZ2VzdElEB2xlbGVtZW50VmFsdWX0cWVsZW1lbnRJZGVudGlmaWVya2FnZV9vdmVyXzY12BhYVqRmcmFuZG9tUEQqTillqXQcpIwC8F2YOMloZGlnZXN0SUQIbGVsZW1lbnRWYWx1ZWJERXFlbGVtZW50SWRlbnRpZmllcnByZXNpZGVudF9jb3VudHJ52BhYT6RmcmFuZG9tUMoKXZZ4ZDwVRRL4IQ7oDEFoZGlnZXN0SUQJbGVsZW1lbnRWYWx1ZfVxZWxlbWVudElkZW50aWZpZXJrYWdlX292ZXJfMTbYGFhXpGZyYW5kb21QdJ-5Oz_55VjO0LOBbnoLs2hkaWdlc3RJRApsZWxlbWVudFZhbHVlYkRFcWVsZW1lbnRJZGVudGlmaWVycWlzc3VpbmdfYXV0aG9yaXR52BhYa6RmcmFuZG9tUMexUIlyfvCgcIUu67OBH6doZGlnZXN0SUQLbGVsZW1lbnRWYWx1ZcB4GDIwMjUtMDItMThUMTQ6MTI6MDQuMzc1WnFlbGVtZW50SWRlbnRpZmllcm1pc3N1YW5jZV9kYXRl2BhYVKRmcmFuZG9tUJ_7jstnoovdbm84Cmh2etFoZGlnZXN0SUQMbGVsZW1lbnRWYWx1ZRkHrHFlbGVtZW50SWRlbnRpZmllcm5hZ2VfYmlydGhfeWVhctgYWFmkZnJhbmRvbVAnc4IFpUS4gxjqo-1DsQNvaGRpZ2VzdElEDWxlbGVtZW50VmFsdWVqTVVTVEVSTUFOTnFlbGVtZW50SWRlbnRpZmllcmtmYW1pbHlfbmFtZdgYWE-kZnJhbmRvbVD0dq9e6pNoaa0e_tVlZ-hZaGRpZ2VzdElEDmxlbGVtZW50VmFsdWX1cWVsZW1lbnRJZGVudGlmaWVya2FnZV9vdmVyXzE42BhYU6RmcmFuZG9tUIurbtyPoiia4qsc62iQHIBoZGlnZXN0SUQPbGVsZW1lbnRWYWx1ZWVFUklLQXFlbGVtZW50SWRlbnRpZmllcmpnaXZlbl9uYW1l2BhYY6RmcmFuZG9tUKgfL0gkbSOApy2APkdkNatoZGlnZXN0SUQQbGVsZW1lbnRWYWx1ZXBIRUlERVNUUkHhup5FIDE3cWVsZW1lbnRJZGVudGlmaWVyb3Jlc2lkZW50X3N0cmVldNgYWFGkZnJhbmRvbVA3gWJEwZz8jgsLsfRJvjMQaGRpZ2VzdElEEWxlbGVtZW50VmFsdWViREVxZWxlbWVudElkZW50aWZpZXJrbmF0aW9uYWxpdHnYGFhPpGZyYW5kb21QHSMBCaBxBPPy92dCcmoZvWhkaWdlc3RJRBJsZWxlbWVudFZhbHVl9XFlbGVtZW50SWRlbnRpZmllcmthZ2Vfb3Zlcl8yMdgYWFakZnJhbmRvbVB4Df01yH0SBmag1gS4xKL9aGRpZ2VzdElEE2xlbGVtZW50VmFsdWVlS8OWTE5xZWxlbWVudElkZW50aWZpZXJtcmVzaWRlbnRfY2l0edgYWFukZnJhbmRvbVDxOTqapogRuHVS1cLoK7z6aGRpZ2VzdElEFGxlbGVtZW50VmFsdWVmR0FCTEVScWVsZW1lbnRJZGVudGlmaWVycWZhbWlseV9uYW1lX2JpcnRo2BhYaaRmcmFuZG9tUOFMkL6pWaVejQQEv7_aS-loZGlnZXN0SUQVbGVsZW1lbnRWYWx1ZcB4GDIwMjUtMDMtMDRUMTQ6MTI6MDQuMzc1WnFlbGVtZW50SWRlbnRpZmllcmtleHBpcnlfZGF0ZQ`;
 /**
@@ -46,6 +47,56 @@ const buildSdJwt = async (payload: Record<string, unknown>) => {
 	await jwt.sign(signer);
 	const sdJwt = new SDJwt({ jwt, disclosures: [] });
 	return sdJwt.encodeSDJwt();
+};
+
+const verifierCertificatePem = `-----BEGIN CERTIFICATE-----
+MIIC5DCCAomgAwIBAgIUJlxjbr618T2Zb2dxCxfzzeTnYMwwCgYIKoZIzj0EAwIw
+PzELMAkGA1UEBhMCRVUxFTATBgNVBAoMDHd3V2FsbGV0Lm9yZzEZMBcGA1UEAwwQ
+d3dXYWxsZXQgUm9vdCBDQTAeFw0yNjAzMjAxMDA3MTlaFw0yNzAzMjAxMDA3MTla
+MEMxCzAJBgNVBAYTAkVVMRUwEwYDVQQKDAx3d1dhbGxldC5vcmcxHTAbBgNVBAMM
+FGV4YW1wbGUud3d3YWxsZXQub3JnMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE
+pRwtHC77yWVX2XpncAlzUyYE0IPjNEqtO2eEXCv3qNhpC5i4QgnFnISr+/SagB4g
+qAq22PZPlHsCukmjscdjiKOCAV0wggFZMB8GA1UdIwQYMBaAFOy9nGNg5magtflH
+l1/bNcrjabgLMB0GA1UdDgQWBBQnp8p5McTXqRqiDe8vc8u6bazIozAOBgNVHQ8B
+Af8EBAMCB4AwOgYDVR0SBDMwMYERaW5mb0B3d3dhbGxldC5vcmeGHGh0dHBzOi8v
+ZXhhbXBsZS53d3dhbGxldC5vcmcwEgYDVR0lBAswCQYHKIGMXQUBBjAMBgNVHRMB
+Af8EAjAAMEwGA1UdHwRFMEMwQaA/oD2GO2h0dHBzOi8vZXhhbXBsZS53d3dhbGxl
+dC5vcmcvaWFjYS9jcmwvd3d3YWxsZXRfb3JnX2lhY2EuY3JsMFsGA1UdEQRUMFKC
+FGV4YW1wbGUud3d3YWxsZXQub3JnghtleGFtcGxlLWlzc3Vlci53d3dhbGxldC5v
+cmeCHWV4YW1wbGUtdmVyaWZpZXIud3d3YWxsZXQub3JnMAoGCCqGSM49BAMCA0kA
+MEYCIQCoUS8pFmhxwEf4pOQULb7GRCcAF/7NEWf9H1buoaLAKAIhAJZAYYsl7mrg
+haC8hh+EFqTdJJJzCyAxThkMjhwKEr8j
+-----END CERTIFICATE-----`;
+
+const verifierPrivateKeyPem = `-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgF+SYouRj+4/uAvQp
+01wTiFSlzNl8yftHOal5GxNXoxmhRANCAASlHC0cLvvJZVfZemdwCXNTJgTQg+M0
+Sq07Z4RcK/eo2GkLmLhCCcWchKv79JqAHiCoCrbY9k+UewK6SaOxx2OI
+-----END PRIVATE KEY-----`;
+
+const verifierCertificateBase64 = verifierCertificatePem
+	.replace("-----BEGIN CERTIFICATE-----", "")
+	.replace("-----END CERTIFICATE-----", "")
+	.replace(/\s+/g, "");
+
+const buildRequestUriJwt = async (clientId: string, dcqlQuery: Record<string, unknown>) => {
+	const privateKey = await importPKCS8(verifierPrivateKeyPem, "ES256");
+	return new SignJWT({
+		client_id: clientId,
+		response_uri: "https://verifier.example.com/cb",
+		state: "state-hash",
+		nonce: "nonce-hash",
+		client_metadata: { vp_formats: {} },
+		response_mode: OpenID4VPResponseMode.DIRECT_POST,
+		dcql_query: dcqlQuery,
+	})
+		.setProtectedHeader({
+			alg: "ES256",
+			x5c: [verifierCertificateBase64],
+			typ: "oauth-authz-req+jwt",
+		})
+		.setIssuedAt()
+		.sign(privateKey);
 };
 
 describe("OpenID4VPServerAPI.handleAuthorizationRequest", () => {
@@ -354,12 +405,30 @@ describe("OpenID4VPServerAPI.handleAuthorizationRequest", () => {
 		assert(result.error === "old_state");
 	});
 
-	it("should accept x509_hash as supported client_id scheme", async () => {
+	it("should accept x509_hash when the request_uri hash matches the signing certificate", async () => {
 		const signedClaimsPid = { vct: "urn:eudi:pid:1", given_name: "Alice" };
 		const sdJwtPid = await buildSdJwt(signedClaimsPid);
+		const expectedClientId = `x509_hash:${Crypto.createHash("sha256").update(Buffer.from(verifierCertificateBase64, "base64")).digest("base64url")}`;
+		const requestUriJwt = await buildRequestUriJwt(expectedClientId, {
+			credentials: [
+				{
+					id: "testCredential",
+					format: VerifiableCredentialFormat.DC_SDJWT,
+					meta: { vct_values: ["urn:eudi:pid:1"] },
+					claims: [{ path: ["given_name"] }],
+				},
+			],
+		});
 
 		const helper = new OpenID4VPServerAPI({
-			httpClient: { get: async () => { throw new Error("unexpected http call"); } },
+			httpClient: {
+				get: async (url: string) => {
+					if (url === "https://verifier.example.com/request-object") {
+						return { data: requestUriJwt };
+					}
+					throw new Error(`unexpected http call: ${url}`);
+				},
+			},
 			rpStateStore: {
 				store: async () => {},
 				retrieve: async () => ({}) as any,
@@ -388,17 +457,19 @@ describe("OpenID4VPServerAPI.handleAuthorizationRequest", () => {
 		};
 
 		const url = new URL("openid4vp://authorize");
-		url.searchParams.set("client_id", "x509_hash:dummyhashvalue");
+		url.searchParams.set("client_id", expectedClientId);
 		url.searchParams.set("response_uri", "https://verifier.example.com/cb");
 		url.searchParams.set("nonce", "nonce-hash");
 		url.searchParams.set("state", "state-hash");
 		url.searchParams.set("client_metadata", JSON.stringify({ vp_formats: {} }));
 		url.searchParams.set("response_mode", JSON.stringify(OpenID4VPResponseMode.DIRECT_POST));
 		url.searchParams.set("dcql_query", JSON.stringify(dcql_query));
+		url.searchParams.set("request_uri", "https://verifier.example.com/request-object");
 
 		const result = await helper.handleAuthorizationRequest(url.toString(), [
 			{ format: VerifiableCredentialFormat.DC_SDJWT, data: sdJwtPid, batchId: 7, instanceId: 0 },
 		]);
 		assert(!("error" in result));
+		assert(result.verifierDomainName === expectedClientId);
 	});
 });

--- a/src/protocols/openid4vp/OpenID4VPServerAPI.ts
+++ b/src/protocols/openid4vp/OpenID4VPServerAPI.ts
@@ -77,6 +77,7 @@ const decoder = new TextDecoder();
 const encoder = new TextEncoder();
 const certFromB64 = (certBase64: string) =>
 	`-----BEGIN CERTIFICATE-----\n${certBase64.match(/.{1,64}/g)?.join("\n")}\n-----END CERTIFICATE-----`;
+const supportedClientIdSchemes = new Set(["x509_san_dns", "x509_hash"]);
 
 function isOpenID4VPResponseMode(value: unknown): value is OpenID4VPResponseMode {
 	return typeof value === "string" && Object.values(OpenID4VPResponseMode).includes(value as OpenID4VPResponseMode);
@@ -92,6 +93,25 @@ function getRandomUUID(randomUUID?: () => string): string {
 	if (randomUUID) return randomUUID();
 	if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID();
 	return generateRandomIdentifier(16);
+}
+
+function getClientIdScheme(clientId: string): string {
+	return clientId.split(":")[0];
+}
+
+async function calculateX509HashFromLeafCert(leafCertBase64: string, subtle?: SubtleCrypto): Promise<string> {
+	let certBytes: Uint8Array;
+	if (typeof Buffer !== "undefined") {
+		certBytes = Uint8Array.from(Buffer.from(leafCertBase64, "base64"));
+	} else {
+		const binary = atob(leafCertBase64);
+		certBytes = new Uint8Array(binary.length);
+		for (let i = 0; i < binary.length; i++) {
+			certBytes[i] = binary.charCodeAt(i);
+		}
+	}
+	const digest = await getSubtleCrypto(subtle).digest("SHA-256", certBytes);
+	return base64url.encode(new Uint8Array(digest));
 }
 
 const retrieveKeys = async (S: OpenID4VPRelyingPartyState, httpClient: { get: (url: string, options?: Record<string, unknown>) => Promise<{ data: unknown }> }) => {
@@ -149,7 +169,7 @@ export class OpenID4VPServerAPI<CredentialT extends OpenID4VPServerCredential, P
 	}
 
 	private async handleRequestUri(request_uri: string): Promise<
-		{ payload: Record<string, unknown>; parsedHeader: Record<string, unknown> } |
+		{ payload: Record<string, unknown>; parsedHeader: Record<string, unknown>; leafCertBase64: string } |
 		{ error: HandleAuthorizationRequestError }
 	> {
 		const requestUriResponse = await this.deps.httpClient.get(request_uri, {});
@@ -164,13 +184,17 @@ export class OpenID4VPServerAPI<CredentialT extends OpenID4VPServerCredential, P
 			return { error: HandleAuthorizationRequestErrors.INVALID_TYP };
 		}
 		const x5c = parsedHeader.x5c as string[];
-		const publicKey = await importX509(certFromB64(x5c[0]), parsedHeader.alg);
+		const leafCertBase64 = x5c?.[0];
+		if (!leafCertBase64) {
+			return { error: HandleAuthorizationRequestErrors.NONTRUSTED_VERIFIER };
+		}
+		const publicKey = await importX509(certFromB64(leafCertBase64), parsedHeader.alg);
 		const verificationResult = await jwtVerify(jwt, publicKey).catch(() => null);
 		if (verificationResult == null) {
 			return { error: HandleAuthorizationRequestErrors.NONTRUSTED_VERIFIER };
 		}
 		const decodedPayload = JSON.parse(decoder.decode(base64url.decode(payload)));
-		return { payload: decodedPayload, parsedHeader };
+		return { payload: decodedPayload, parsedHeader, leafCertBase64 };
 	}
 
 	private async matchCredentialsToDCQL(vcList: CredentialT[], dcqlJson: any): Promise<
@@ -589,8 +613,8 @@ export class OpenID4VPServerAPI<CredentialT extends OpenID4VPServerCredential, P
 			return { error: HandleAuthorizationRequestErrors.COULD_NOT_RESOLVE_REQUEST };
 		}
 
-		const client_id_scheme = client_id.split(":")[0];
-		if (client_id_scheme !== "x509_san_dns") {
+		const client_id_scheme = getClientIdScheme(client_id);
+		if (!supportedClientIdSchemes.has(client_id_scheme)) {
 			return { error: HandleAuthorizationRequestErrors.NON_SUPPORTED_CLIENT_ID_SCHEME };
 		}
 
@@ -601,8 +625,18 @@ export class OpenID4VPServerAPI<CredentialT extends OpenID4VPServerCredential, P
 				if ("error" in result) {
 					return result;
 				}
-				const { payload, parsedHeader } = result;
+				const { payload, parsedHeader, leafCertBase64 } = result;
 				client_id = payload.client_id as string;
+				const requestObjectClientIdScheme = getClientIdScheme(client_id);
+				if (!supportedClientIdSchemes.has(requestObjectClientIdScheme)) {
+					return { error: HandleAuthorizationRequestErrors.NON_SUPPORTED_CLIENT_ID_SCHEME };
+				}
+				if (requestObjectClientIdScheme === "x509_hash") {
+					const expectedClientId = `x509_hash:${await calculateX509HashFromLeafCert(leafCertBase64, this.deps.subtle)}`;
+					if (client_id !== expectedClientId) {
+						return { error: HandleAuthorizationRequestErrors.NONTRUSTED_VERIFIER };
+					}
+				}
 
 				dcql_query = payload.dcql_query ?? dcql_query;
 				response_uri = (payload.response_uri ?? payload.redirect_uri) as string;

--- a/src/protocols/openid4vp/types.ts
+++ b/src/protocols/openid4vp/types.ts
@@ -81,6 +81,8 @@ export enum OpenID4VPResponseMode {
 	DC_API_JWT = "dc_api.jwt",
 }
 
+export type OpenID4VPClientIdScheme = "x509_san_dns" | "x509_hash";
+
 export type OpenID4VPClientMetadata = {
 	jwks?: { keys: any[] };
 	jwks_uri?: string;


### PR DESCRIPTION
Add support for x509_hash: Client Identifier Prefix in OpenID4VP (client + server logic and types).

Reference:
https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-5.9.3-3.6.1
