### PR TITLE
OpenID4VP: Response encryption fixes (1.0)

### DIFF
--- a/src/protocols/openid4vp/OpenID4VPClientAPI.test.ts
+++ b/src/protocols/openid4vp/OpenID4VPClientAPI.test.ts
@@ -97,6 +97,8 @@ describe("OpenID4VPClientAPI.generateAuthorizationRequestURL", () => {
 		assert(payload.dcql_query?.credentials?.[0]?.id === "pidMsoMdoc");
 		assert(!("transaction_data" in payload));
 		assert(payload.client_metadata?.jwks?.keys?.length === 1);
+		assert(payload.client_metadata?.jwks?.keys?.[0]?.alg === "ECDH-ES");
+		assert(result.rpState.rp_eph_pub.alg === "ECDH-ES");
 	});
 
 	it("should build a valid URL using x509_hash client identifier", async () => {
@@ -144,9 +146,11 @@ describe("OpenID4VPClientAPI.generateAuthorizationRequestURL", () => {
 
 		assert(result.url.searchParams.get("client_id") === expectedClientId);
 		assert(result.rpState.audience === expectedClientId);
+		assert(result.rpState.rp_eph_pub.alg === "ECDH-ES");
 		const [, encodedPayload] = result.rpState.signed_request.split(".");
 		const payload = JSON.parse(new TextDecoder().decode(fromBase64Url(encodedPayload)));
 		assert(payload.client_id === expectedClientId);
+		assert(payload.client_metadata?.jwks?.keys?.[0]?.alg === "ECDH-ES");
 	});
 });
 

--- a/src/protocols/openid4vp/OpenID4VPClientAPI.ts
+++ b/src/protocols/openid4vp/OpenID4VPClientAPI.ts
@@ -161,6 +161,7 @@ export class OpenID4VPClientAPI {
 		exportedEphPub.kid = generateRandomIdentifier(8);
 		exportedEphPriv.kid = exportedEphPub.kid;
 		exportedEphPub.use = 'enc';
+		exportedEphPub.alg = 'ECDH-ES';
 		let transactionDataObject: any[] = [];
 		if (presentationRequest?.dcql_query?.credentials) {
 			transactionDataObject = await Promise.all(presentationRequest?.dcql_query?.credentials
@@ -195,8 +196,7 @@ export class OpenID4VPClientAPI {
 						exportedEphPub
 					]
 				},
-				"authorization_encrypted_response_alg": "ECDH-ES",
-				"authorization_encrypted_response_enc": "A256GCM",
+				"encrypted_response_enc_values_supported": ["A256GCM"],
 				"vp_formats": {
 					"vc+sd-jwt": {
 						"sd-jwt_alg_values": [

--- a/src/protocols/openid4vp/OpenID4VPServerAPI.test.ts
+++ b/src/protocols/openid4vp/OpenID4VPServerAPI.test.ts
@@ -477,7 +477,7 @@ describe("OpenID4VPServerAPI.handleAuthorizationRequest", () => {
 });
 
 describe("OpenID4VPServerAPI.createAuthorizationResponse", () => {
-	const createJwtResponse = async (encryptedResponseEncValuesSupported: string[]) => {
+	const createJwtResponse = async (encryptedResponseEncValuesSupported?: string[]) => {
 		const signedClaims = { vct: "urn:eudi:pid:1", given_name: "Alice" };
 		const sdJwtPid = await buildSdJwt(signedClaims);
 		const { publicKey } = await generateKeyPair("ECDH-ES");
@@ -494,7 +494,9 @@ describe("OpenID4VPServerAPI.createAuthorizationResponse", () => {
 					state: "state-jwe",
 					client_metadata: {
 						vp_formats: {},
-						encrypted_response_enc_values_supported: encryptedResponseEncValuesSupported,
+						...(encryptedResponseEncValuesSupported
+							? { encrypted_response_enc_values_supported: encryptedResponseEncValuesSupported }
+							: {}),
 						jwks: { keys: [{ ...jwk, use: "enc", alg: "ECDH-ES", kid: "kid-jwe" }] },
 					},
 					response_mode: OpenID4VPResponseMode.DIRECT_POST_JWT,
@@ -539,8 +541,18 @@ describe("OpenID4VPServerAPI.createAuthorizationResponse", () => {
 		assert(decodeJweProtectedHeader(jwe).enc === OpenID4VPJweEncryption.A256GCM);
 	});
 
-	it("falls back to A128GCM when verifier JWE enc values are unsupported", async () => {
-		const jwe = await createJwtResponse(["unsupported"]);
+	it("throws when verifier JWE enc values are provided but unsupported", async () => {
+		try {
+			await createJwtResponse(["unsupported"]);
+			assert.fail("Expected createAuthorizationResponse to throw for unsupported enc values");
+		} catch (error) {
+			assert(error instanceof Error);
+			assert(error.message.includes("Could not find supported algorithm in encrypted_response_enc_values_supported"));
+		}
+	});
+
+	it("falls back to A128GCM when verifier JWE enc values are not provided", async () => {
+		const jwe = await createJwtResponse();
 
 		assert(decodeJweProtectedHeader(jwe).enc === OpenID4VPJweEncryption.A128GCM);
 	});

--- a/src/protocols/openid4vp/OpenID4VPServerAPI.test.ts
+++ b/src/protocols/openid4vp/OpenID4VPServerAPI.test.ts
@@ -2,9 +2,9 @@ import { assert, describe, it } from "vitest";
 import Crypto from "node:crypto";
 import { Jwt, SDJwt } from "@sd-jwt/core";
 import { OpenID4VPServerAPI, retrieveKeys } from "./OpenID4VPServerAPI";
-import { OpenID4VPResponseMode } from "./types";
+import { OpenID4VPJweEncryption, OpenID4VPResponseMode } from "./types";
 import { VerifiableCredentialFormat } from "../../types";
-import { SignJWT, importPKCS8 } from "jose";
+import { SignJWT, exportJWK, generateKeyPair, importPKCS8 } from "jose";
 
 const issuerSignedB64U = `omppc3N1ZXJBdXRohEOhASahGCGCWQJ4MIICdDCCAhugAwIBAgIBAjAKBggqhkjOPQQDAjCBiDELMAkGA1UEBhMCREUxDzANBgNVBAcMBkJlcmxpbjEdMBsGA1UECgwUQnVuZGVzZHJ1Y2tlcmVpIEdtYkgxETAPBgNVBAsMCFQgQ1MgSURFMTYwNAYDVQQDDC1TUFJJTkQgRnVua2UgRVVESSBXYWxsZXQgUHJvdG90eXBlIElzc3VpbmcgQ0EwHhcNMjQwNTMxMDgxMzE3WhcNMjUwNzA1MDgxMzE3WjBsMQswCQYDVQQGEwJERTEdMBsGA1UECgwUQnVuZGVzZHJ1Y2tlcmVpIEdtYkgxCjAIBgNVBAsMAUkxMjAwBgNVBAMMKVNQUklORCBGdW5rZSBFVURJIFdhbGxldCBQcm90b3R5cGUgSXNzdWVyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOFBq4YMKg4w5fTifsytwBuJf_7E7VhRPXiNm52S3q1ETIgBdXyDK3kVxGxgeHPivLP3uuMvS6iDEc7qMxmvduKOBkDCBjTAdBgNVHQ4EFgQUiPhCkLErDXPLW2_J0WVeghyw-mIwDAYDVR0TAQH_BAIwADAOBgNVHQ8BAf8EBAMCB4AwLQYDVR0RBCYwJIIiZGVtby5waWQtaXNzdWVyLmJ1bmRlc2RydWNrZXJlaS5kZTAfBgNVHSMEGDAWgBTUVhjAiTjoDliEGMl2Yr-ru8WQvjAKBggqhkjOPQQDAgNHADBEAiAbf5TzkcQzhfWoIoyi1VN7d8I9BsFKm1MWluRph2byGQIgKYkdrNf2xXPjVSbjW_U_5S5vAEC5XxcOanusOBroBbVZAn0wggJ5MIICIKADAgECAhQHkT1BVm2ZRhwO0KMoH8fdVC_vaDAKBggqhkjOPQQDAjCBiDELMAkGA1UEBhMCREUxDzANBgNVBAcMBkJlcmxpbjEdMBsGA1UECgwUQnVuZGVzZHJ1Y2tlcmVpIEdtYkgxETAPBgNVBAsMCFQgQ1MgSURFMTYwNAYDVQQDDC1TUFJJTkQgRnVua2UgRVVESSBXYWxsZXQgUHJvdG90eXBlIElzc3VpbmcgQ0EwHhcNMjQwNTMxMDY0ODA5WhcNMzQwNTI5MDY0ODA5WjCBiDELMAkGA1UEBhMCREUxDzANBgNVBAcMBkJlcmxpbjEdMBsGA1UECgwUQnVuZGVzZHJ1Y2tlcmVpIEdtYkgxETAPBgNVBAsMCFQgQ1MgSURFMTYwNAYDVQQDDC1TUFJJTkQgRnVua2UgRVVESSBXYWxsZXQgUHJvdG90eXBlIElzc3VpbmcgQ0EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARgbN3AUOdzv4qfmJsC8I4zyR7vtVDGp8xzBkvwhogD5YJE5wJ-Zj-CIf3aoyu7mn-TI6K8TREL8ht0w428OhTJo2YwZDAdBgNVHQ4EFgQU1FYYwIk46A5YhBjJdmK_q7vFkL4wHwYDVR0jBBgwFoAU1FYYwIk46A5YhBjJdmK_q7vFkL4wEgYDVR0TAQH_BAgwBgEB_wIBADAOBgNVHQ8BAf8EBAMCAYYwCgYIKoZIzj0EAwIDRwAwRAIgYSbvCRkoe39q1vgx0WddbrKufAxRPa7XfqB22XXRjqECIG5MWq9Vi2HWtvHMI_TFZkeZAr2RXLGfwY99fbsQjPOzWQS62BhZBLWnZnN0YXR1c6Frc3RhdHVzX2xpc3SiY2lkeBhsY3VyaXhWaHR0cHM6Ly9kZW1vLnBpZC1pc3N1ZXIuYnVuZGVzZHJ1Y2tlcmVpLmRlL3N0YXR1cy84ODc5M2MwMy0xNmFkLTQ0NjgtYmVmNy1jMDgzZDM4YWUyMTlnZG9jVHlwZXdldS5ldXJvcGEuZWMuZXVkaS5waWQuMWd2ZXJzaW9uYzEuMGx2YWxpZGl0eUluZm-jZnNpZ25lZMB0MjAyNS0wMi0xOFQxNDoxMjowNFppdmFsaWRGcm9twHQyMDI1LTAyLTE4VDE0OjEyOjA0Wmp2YWxpZFVudGlswHQyMDI1LTAzLTA0VDE0OjEyOjA0Wmx2YWx1ZURpZ2VzdHOhd2V1LmV1cm9wYS5lYy5ldWRpLnBpZC4xtgBYIKuGxnFMGhNio5-VUJKePlkmw33mloMA9fgqUR0ynOoJAVggWxNyUrVxTPW2riSGxx_U_irluD-vcJIOGGrafGo6JpwCWCDKOCdlxlbeX7mztFkzrM7MsZHs3gEyrmC79X3N2VpxkgNYICmI6iaQPBePM7fzBXqPyX5Gr-wNnWNCNb7wDUz4VDIRBFggfCuu8bFboi9BiRPsM447Ncg9A7K7A28iTEjVy9fmjBIFWCC6z1AlQM8ttJfuIQtPYlurlamh3MvAbSaQoUzAn-9L9gZYIKD1mVbZ5zb-_sp_E6vZCQ_U2QAQVNtbWAznR4xUm6LoB1ggWAn0OSPMM-m8NbgBZ-D6qLV0BEVeSnR4DIsUPUOZDbsIWCDyTDBH9XjK_JIq_W7d19UpmMq1pd1CjrmhfIHsctg3gwlYIK7ejRc3g-pfNGM0WHv4Oh1jfshl03Jvm3cxKHFnIIXmClggjPVDgZmiJEpnM6Zo_mzUQAbW5M6QZuRH43L6BqVeT7wLWCCSVNDu2CjnRkbC7_6m6-G6h8dTDWvlmGz0WD-MUCGERwxYIDpAXdFHgnACMgICXQpJi9nzBDRjsJ8bY1htM9GtgZlKDVggvhyWJk8WGQgokFghnd9DyZKyo8b6VrfAX8WTB0vH1QkOWCBLJFY_nbKL1x-5fbJCqS1IgEn_uMm9NJm2vqorCWwwPg9YIJIg7rTS_E3HAYjcjdV6WSpgZuXa8IKo7f5aC9ibPXQzEFggc_BlS8FdmjVtSqXrA2Xh58naoO0XdTbwclGo9itNTIERWCDzIo5muAIWaawEG69bUPG4mI4pEB5dUhadaUeMUEuwIhJYIEALsAqnwl3T1nC7YtOeDj-7OEHlmcwhCZjY2Qgsr2vCE1ggwG6In0GuGqO1isPXfh2EA7-mi18JAhfumCyQUA5FpYYUWCAL6kBisfFYUIU06t2d0UeqElM-c49VrVqfgYYSIx2JpRVYICYx93c95xCPFdhE03ZlReMnLGSjT_SJgEBMeErv0VlXbWRldmljZUtleUluZm-haWRldmljZUtleaQBAiABIVgganiJYJ0goJBbFzWZ52BDtTvTP1Fqb6k80C4UBl6JrFwiWCCWf2o4RIOTRI_UGubc0rCyIDo-o_LYRzYRnWzos3gcSm9kaWdlc3RBbGdvcml0aG1nU0hBLTI1NlhAcBP9-i1suGc_TnH7z4Mp8jFAz2Q__4w7Ju7dDG93XWfCE15E15WYaXUnkYY80tStLInk7nEi6IqEPHJPUyWiyGpuYW1lU3BhY2VzoXdldS5ldXJvcGEuZWMuZXVkaS5waWQuMZbYGFhRpGZyYW5kb21Q6lwO6tOJcjKhPDMrRPrRFGhkaWdlc3RJRABsZWxlbWVudFZhbHVlGDxxZWxlbWVudElkZW50aWZpZXJsYWdlX2luX3llYXJz2BhYT6RmcmFuZG9tUBwuvU0MGGbT2h94xazpeqloZGlnZXN0SUQBbGVsZW1lbnRWYWx1ZfVxZWxlbWVudElkZW50aWZpZXJrYWdlX292ZXJfMTLYGFhdpGZyYW5kb21Qo6kOsHqedb_9xHVlfCXHf2hkaWdlc3RJRAJsZWxlbWVudFZhbHVlZTUxMTQ3cWVsZW1lbnRJZGVudGlmaWVydHJlc2lkZW50X3Bvc3RhbF9jb2Rl2BhYVaRmcmFuZG9tUP6aK3BnaJ4ssYCnhgPSaZpoZGlnZXN0SUQDbGVsZW1lbnRWYWx1ZWZCRVJMSU5xZWxlbWVudElkZW50aWZpZXJrYmlydGhfcGxhY2XYGFhPpGZyYW5kb21QGR_ZD_ylLFjp_gFyoXxR0WhkaWdlc3RJRARsZWxlbWVudFZhbHVl9XFlbGVtZW50SWRlbnRpZmllcmthZ2Vfb3Zlcl8xNNgYWFWkZnJhbmRvbVByTlMf_mCOUvaECM5veox_aGRpZ2VzdElEBWxlbGVtZW50VmFsdWViREVxZWxlbWVudElkZW50aWZpZXJvaXNzdWluZ19jb3VudHJ52BhYY6RmcmFuZG9tUED3uH1EYolIFfAdQr8v6pVoZGlnZXN0SUQGbGVsZW1lbnRWYWx1ZcB0MTk2NC0wOC0xMlQwMDowMDowMFpxZWxlbWVudElkZW50aWZpZXJqYmlydGhfZGF0ZdgYWE-kZnJhbmRvbVBucDIRMDGt1bMXZVQopw3OaGRpZ2VzdElEB2xlbGVtZW50VmFsdWX0cWVsZW1lbnRJZGVudGlmaWVya2FnZV9vdmVyXzY12BhYVqRmcmFuZG9tUEQqTillqXQcpIwC8F2YOMloZGlnZXN0SUQIbGVsZW1lbnRWYWx1ZWJERXFlbGVtZW50SWRlbnRpZmllcnByZXNpZGVudF9jb3VudHJ52BhYT6RmcmFuZG9tUMoKXZZ4ZDwVRRL4IQ7oDEFoZGlnZXN0SUQJbGVsZW1lbnRWYWx1ZfVxZWxlbWVudElkZW50aWZpZXJrYWdlX292ZXJfMTbYGFhXpGZyYW5kb21QdJ-5Oz_55VjO0LOBbnoLs2hkaWdlc3RJRApsZWxlbWVudFZhbHVlYkRFcWVsZW1lbnRJZGVudGlmaWVycWlzc3VpbmdfYXV0aG9yaXR52BhYa6RmcmFuZG9tUMexUIlyfvCgcIUu67OBH6doZGlnZXN0SUQLbGVsZW1lbnRWYWx1ZcB4GDIwMjUtMDItMThUMTQ6MTI6MDQuMzc1WnFlbGVtZW50SWRlbnRpZmllcm1pc3N1YW5jZV9kYXRl2BhYVKRmcmFuZG9tUJ_7jstnoovdbm84Cmh2etFoZGlnZXN0SUQMbGVsZW1lbnRWYWx1ZRkHrHFlbGVtZW50SWRlbnRpZmllcm5hZ2VfYmlydGhfeWVhctgYWFmkZnJhbmRvbVAnc4IFpUS4gxjqo-1DsQNvaGRpZ2VzdElEDWxlbGVtZW50VmFsdWVqTVVTVEVSTUFOTnFlbGVtZW50SWRlbnRpZmllcmtmYW1pbHlfbmFtZdgYWE-kZnJhbmRvbVD0dq9e6pNoaa0e_tVlZ-hZaGRpZ2VzdElEDmxlbGVtZW50VmFsdWX1cWVsZW1lbnRJZGVudGlmaWVya2FnZV9vdmVyXzE42BhYU6RmcmFuZG9tUIurbtyPoiia4qsc62iQHIBoZGlnZXN0SUQPbGVsZW1lbnRWYWx1ZWVFUklLQXFlbGVtZW50SWRlbnRpZmllcmpnaXZlbl9uYW1l2BhYY6RmcmFuZG9tUKgfL0gkbSOApy2APkdkNatoZGlnZXN0SUQQbGVsZW1lbnRWYWx1ZXBIRUlERVNUUkHhup5FIDE3cWVsZW1lbnRJZGVudGlmaWVyb3Jlc2lkZW50X3N0cmVldNgYWFGkZnJhbmRvbVA3gWJEwZz8jgsLsfRJvjMQaGRpZ2VzdElEEWxlbGVtZW50VmFsdWViREVxZWxlbWVudElkZW50aWZpZXJrbmF0aW9uYWxpdHnYGFhPpGZyYW5kb21QHSMBCaBxBPPy92dCcmoZvWhkaWdlc3RJRBJsZWxlbWVudFZhbHVl9XFlbGVtZW50SWRlbnRpZmllcmthZ2Vfb3Zlcl8yMdgYWFakZnJhbmRvbVB4Df01yH0SBmag1gS4xKL9aGRpZ2VzdElEE2xlbGVtZW50VmFsdWVlS8OWTE5xZWxlbWVudElkZW50aWZpZXJtcmVzaWRlbnRfY2l0edgYWFukZnJhbmRvbVDxOTqapogRuHVS1cLoK7z6aGRpZ2VzdElEFGxlbGVtZW50VmFsdWVmR0FCTEVScWVsZW1lbnRJZGVudGlmaWVycWZhbWlseV9uYW1lX2JpcnRo2BhYaaRmcmFuZG9tUOFMkL6pWaVejQQEv7_aS-loZGlnZXN0SUQVbGVsZW1lbnRWYWx1ZcB4GDIwMjUtMDMtMDRUMTQ6MTI6MDQuMzc1WnFlbGVtZW50SWRlbnRpZmllcmtleHBpcnlfZGF0ZQ`;
 /**
@@ -98,6 +98,8 @@ const buildRequestUriJwt = async (clientId: string, dcqlQuery: Record<string, un
 		.setIssuedAt()
 		.sign(privateKey);
 };
+
+const decodeJweProtectedHeader = (jwe: string) => JSON.parse(Buffer.from(jwe.split(".")[0], "base64url").toString());
 
 describe("OpenID4VPServerAPI.handleAuthorizationRequest", () => {
 	it("should store rpState and return mapping for an sd-jwt DCQL query", async () => {
@@ -471,6 +473,76 @@ describe("OpenID4VPServerAPI.handleAuthorizationRequest", () => {
 		]);
 		assert(!("error" in result));
 		assert(result.verifierDomainName === expectedClientId);
+	});
+});
+
+describe("OpenID4VPServerAPI.createAuthorizationResponse", () => {
+	const createJwtResponse = async (encryptedResponseEncValuesSupported: string[]) => {
+		const signedClaims = { vct: "urn:eudi:pid:1", given_name: "Alice" };
+		const sdJwtPid = await buildSdJwt(signedClaims);
+		const { publicKey } = await generateKeyPair("ECDH-ES");
+		const jwk = await exportJWK(publicKey);
+
+		const helper = new OpenID4VPServerAPI({
+			httpClient: { get: async () => { throw new Error("unexpected http call"); } },
+			rpStateStore: {
+				store: async () => {},
+				retrieve: async () => ({
+					nonce: "nonce-jwe",
+					response_uri: "https://verifier.example.com/cb",
+					client_id: "x509_san_dns:verifier.example.com",
+					state: "state-jwe",
+					client_metadata: {
+						vp_formats: {},
+						encrypted_response_enc_values_supported: encryptedResponseEncValuesSupported,
+						jwks: { keys: [{ ...jwk, use: "enc", alg: "ECDH-ES", kid: "kid-jwe" }] },
+					},
+					response_mode: OpenID4VPResponseMode.DIRECT_POST_JWT,
+					dcql_query: {
+						credentials: [
+							{
+								id: "pid",
+								format: VerifiableCredentialFormat.DC_SDJWT,
+								meta: { vct_values: ["urn:eudi:pid:1"] },
+								claims: [{ path: ["given_name"] }],
+							},
+						],
+					},
+					transaction_data: [],
+				}),
+			},
+			parseCredential: async () => ({ signedClaims }),
+			selectCredentialForBatch: async (batchId, vcEntityList) =>
+				vcEntityList.find((credential) => credential.batchId === batchId) ?? null,
+			keystore: {
+				signJwtPresentation: async () => ({ vpjwt: "vp-jwt" }),
+				generateDeviceResponse: async () => ({ deviceResponseMDoc: {} }),
+			},
+			strings: {
+				purposeNotSpecified: "No purpose provided",
+				allClaimsRequested: "All claims",
+			},
+		});
+
+		const result = await helper.createAuthorizationResponse(
+			new Map([["pid", 7]]),
+			[{ format: VerifiableCredentialFormat.DC_SDJWT, data: sdJwtPid, batchId: 7 }]
+		);
+
+		assert("formData" in result);
+		return result.formData.get("response") as string;
+	};
+
+	it("uses the first supported verifier JWE enc value", async () => {
+		const jwe = await createJwtResponse(["unsupported", OpenID4VPJweEncryption.A256GCM]);
+
+		assert(decodeJweProtectedHeader(jwe).enc === OpenID4VPJweEncryption.A256GCM);
+	});
+
+	it("falls back to A128GCM when verifier JWE enc values are unsupported", async () => {
+		const jwe = await createJwtResponse(["unsupported"]);
+
+		assert(decodeJweProtectedHeader(jwe).enc === OpenID4VPJweEncryption.A128GCM);
 	});
 });
 

--- a/src/protocols/openid4vp/OpenID4VPServerAPI.test.ts
+++ b/src/protocols/openid4vp/OpenID4VPServerAPI.test.ts
@@ -1,7 +1,7 @@
 import { assert, describe, it } from "vitest";
 import Crypto from "node:crypto";
 import { Jwt, SDJwt } from "@sd-jwt/core";
-import { OpenID4VPServerAPI } from "./OpenID4VPServerAPI";
+import { OpenID4VPServerAPI, retrieveKeys } from "./OpenID4VPServerAPI";
 import { OpenID4VPResponseMode } from "./types";
 import { VerifiableCredentialFormat } from "../../types";
 import { SignJWT, importPKCS8 } from "jose";
@@ -471,5 +471,190 @@ describe("OpenID4VPServerAPI.handleAuthorizationRequest", () => {
 		]);
 		assert(!("error" in result));
 		assert(result.verifierDomainName === expectedClientId);
+	});
+});
+
+
+describe("OpenID4VPServerAPI.retrieveKeys", () => {
+	it("should return the key and its alg when jwks is provided directly", async () => {
+		const testKey = {
+			kty: "EC",
+			crv: "P-256",
+			use: "enc",
+			alg: "ECDH-ES+HKDF-256+A128KW",
+			x: "WKn-ZIGevcwGIyyrzFoZNBdaq9_TsqzGl96oc0CWuis",
+			y: "y77t-RvAHRKTsSGdIYUfweuOvwrvDD-Q3Hv5J0fSKbE",
+		};
+
+		const state = {
+			client_metadata: {
+				jwks: {
+					keys: [testKey],
+				},
+			},
+		} as any;
+
+		const result = await retrieveKeys(state, {});
+		assert(result.rp_eph_pub_jwk === testKey);
+		assert(result.alg === "ECDH-ES+HKDF-256+A128KW");
+	});
+
+	it("should fetch keys from jwks_uri and return the key with its alg", async () => {
+		const testKey = {
+			kty: "EC",
+			crv: "P-256",
+			use: "enc",
+			alg: "ECDH-ES+HKDF-256+A128KW",
+			x: "WKn-ZIGevcwGIyyrzFoZNBdaq9_TsqzGl96oc0CWuis",
+			y: "y77t-RvAHRKTsSGdIYUfweuOvwrvDD-Q3Hv5J0fSKbE",
+		};
+
+		const state = {
+			client_metadata: {
+				jwks_uri: "https://example.com/.well-known/jwks.json",
+			},
+		} as any;
+
+		const httpClient = {
+			get: async (url: string) => {
+				if (url === "https://example.com/.well-known/jwks.json") {
+					return { data: { keys: [testKey] } };
+				}
+				throw new Error(`unexpected http call: ${url}`);
+			},
+		};
+
+		const result = await retrieveKeys(state, httpClient);
+		assert(result.rp_eph_pub_jwk === testKey);
+		assert(result.alg === "ECDH-ES+HKDF-256+A128KW");
+	});
+
+	it("should throw error when selected jwks key is missing alg", async () => {
+		const testKey = {
+			kty: "EC",
+			crv: "P-256",
+			use: "enc",
+			x: "WKn-ZIGevcwGIyyrzFoZNBdaq9_TsqzGl96oc0CWuis",
+			y: "y77t-RvAHRKTsSGdIYUfweuOvwrvDD-Q3Hv5J0fSKbE",
+		};
+
+		const state = {
+			client_metadata: {
+				jwks: {
+					keys: [testKey],
+				},
+			},
+		} as any;
+
+		try {
+			await retrieveKeys(state, {});
+			assert(false, "Should have thrown an error");
+		} catch (error) {
+			assert((error as Error).message === "alg is required in verifier's JWK");
+		}
+	});
+
+	it("should throw error when fetched jwks key is missing alg", async () => {
+		const testKey = {
+			kty: "EC",
+			crv: "P-256",
+			use: "enc",
+			x: "WKn-ZIGevcwGIyyrzFoZNBdaq9_TsqzGl96oc0CWuis",
+			y: "y77t-RvAHRKTsSGdIYUfweuOvwrvDD-Q3Hv5J0fSKbE",
+		};
+
+		const state = {
+			client_metadata: {
+				jwks_uri: "https://example.com/.well-known/jwks.json",
+			},
+		} as any;
+
+		const httpClient = {
+			get: async (url: string) => {
+				if (url === "https://example.com/.well-known/jwks.json") {
+					return { data: { keys: [testKey] } };
+				}
+				throw new Error(`unexpected http call: ${url}`);
+			},
+		};
+
+		try {
+			await retrieveKeys(state, httpClient);
+			assert(false, "Should have thrown an error");
+		} catch (error) {
+			assert((error as Error).message === "alg is required in verifier's JWK");
+		}
+	});
+
+	it("should throw error when no encryption keys in jwks", async () => {
+		const nonEncryptionKey = {
+			kty: "EC",
+			crv: "P-256",
+			use: "sig", // Not for encryption
+			alg: "ES256",
+			x: "WKn-ZIGevcwGIyyrzFoZNBdaq9_TsqzGl96oc0CWuis",
+			y: "y77t-RvAHRKTsSGdIYUfweuOvwrvDD-Q3Hv5J0fSKbE",
+		};
+
+		const state = {
+			client_metadata: {
+				jwks: {
+					keys: [nonEncryptionKey],
+				},
+			},
+		} as any;
+
+		try {
+			await retrieveKeys(state, {});
+			assert(false, "Should have thrown an error");
+		} catch (error) {
+			assert((error as Error).message === "Could not find Relying Party public key for encryption");
+		}
+	});
+
+	it("should throw error when no encryption keys in fetched jwks_uri", async () => {
+		const nonEncryptionKey = {
+			kty: "EC",
+			crv: "P-256",
+			use: "sig", // Not for encryption
+			alg: "ES256",
+			x: "WKn-ZIGevcwGIyyrzFoZNBdaq9_TsqzGl96oc0CWuis",
+			y: "y77t-RvAHRKTsSGdIYUfweuOvwrvDD-Q3Hv5J0fSKbE",
+		};
+
+		const state = {
+			client_metadata: {
+				jwks_uri: "https://example.com/.well-known/jwks.json",
+			},
+		} as any;
+
+		const httpClient = {
+			get: async (url: string) => {
+				if (url === "https://example.com/.well-known/jwks.json") {
+					return { data: { keys: [nonEncryptionKey] } };
+				}
+				throw new Error(`unexpected http call: ${url}`);
+			},
+		};
+
+		try {
+			await retrieveKeys(state, httpClient);
+			assert(false, "Should have thrown an error");
+		} catch (error) {
+			assert((error as Error).message === "Could not find Relying Party public key for encryption");
+		}
+	});
+
+	it("should throw error when neither jwks nor jwks_uri provided", async () => {
+		const state = {
+			client_metadata: {},
+		} as any;
+
+		try {
+			await retrieveKeys(state, {});
+			assert(false, "Should have thrown an error");
+		} catch (error) {
+			assert((error as Error).message === "Could not find Relying Party public key for encryption");
+		}
 	});
 });

--- a/src/protocols/openid4vp/OpenID4VPServerAPI.ts
+++ b/src/protocols/openid4vp/OpenID4VPServerAPI.ts
@@ -564,12 +564,16 @@ export class OpenID4VPServerAPI<CredentialT extends OpenID4VPServerCredential, P
 		const formData = new URLSearchParams();
 
 		if ([OpenID4VPResponseMode.DIRECT_POST_JWT, OpenID4VPResponseMode.DC_API_JWT].includes(S.response_mode)) {
-			let jweEnc: string = OpenID4VPJweEncryption.A128GCM;
+			let jweEnc: string;
 			if (S.client_metadata.encrypted_response_enc_values_supported) {
-				jweEnc =
-					S.client_metadata.encrypted_response_enc_values_supported.find((enc) =>
-						supportedJweEncryptions.has(enc)
-					) ?? jweEnc;
+				const firstSupportedEnc = S.client_metadata.encrypted_response_enc_values_supported.find(
+					(enc) => supportedJweEncryptions.has(enc));
+				if (!firstSupportedEnc) {
+					throw new Error("Could not find supported algorithm in encrypted_response_enc_values_supported");
+				}
+				jweEnc = firstSupportedEnc;
+			} else {
+				jweEnc = OpenID4VPJweEncryption.A128GCM;
 			}
 			const { rp_eph_pub_jwk, alg } = await retrieveKeys(S, this.deps.httpClient);
 

--- a/src/protocols/openid4vp/OpenID4VPServerAPI.ts
+++ b/src/protocols/openid4vp/OpenID4VPServerAPI.ts
@@ -11,6 +11,7 @@ import {
 	OpenID4VPServerRequestVerifier,
 	OpenID4VPServerMessages,
 	OpenID4VPResponseMode,
+	OpenID4VPJweEncryption,
 	TransactionDataResponseGenerator,
 	TransactionDataResponseGeneratorParams,
 	TransactionDataResponseParams
@@ -78,6 +79,7 @@ const encoder = new TextEncoder();
 const certFromB64 = (certBase64: string) =>
 	`-----BEGIN CERTIFICATE-----\n${certBase64.match(/.{1,64}/g)?.join("\n")}\n-----END CERTIFICATE-----`;
 const supportedClientIdSchemes = new Set(["x509_san_dns", "x509_hash"]);
+const supportedJweEncryptions = new Set<string>(Object.values(OpenID4VPJweEncryption));
 
 function isOpenID4VPResponseMode(value: unknown): value is OpenID4VPResponseMode {
 	return typeof value === "string" && Object.values(OpenID4VPResponseMode).includes(value as OpenID4VPResponseMode);
@@ -562,12 +564,15 @@ export class OpenID4VPServerAPI<CredentialT extends OpenID4VPServerCredential, P
 		const formData = new URLSearchParams();
 
 		if ([OpenID4VPResponseMode.DIRECT_POST_JWT, OpenID4VPResponseMode.DC_API_JWT].includes(S.response_mode)) {
-			let jweEnc = "A128GCM"; // TODO: use enum from wallet-common if available
+			let jweEnc: string = OpenID4VPJweEncryption.A128GCM;
 			if (S.client_metadata.encrypted_response_enc_values_supported) {
-				jweEnc = S.client_metadata.encrypted_response_enc_values_supported[0]; // TODO: check if supported by EncyptJWE first
+				jweEnc =
+					S.client_metadata.encrypted_response_enc_values_supported.find((enc) =>
+						supportedJweEncryptions.has(enc)
+					) ?? jweEnc;
 			}
 			const { rp_eph_pub_jwk, alg } = await retrieveKeys(S, this.deps.httpClient);
-			console.log("ALG=", alg);
+
 			const rp_eph_pub = await importJWK(rp_eph_pub_jwk, alg);
 
 			const jwePayload = {

--- a/src/protocols/openid4vp/OpenID4VPServerAPI.ts
+++ b/src/protocols/openid4vp/OpenID4VPServerAPI.ts
@@ -114,13 +114,16 @@ async function calculateX509HashFromLeafCert(leafCertBase64: string, subtle?: Su
 	return base64url.encode(new Uint8Array(digest));
 }
 
-const retrieveKeys = async (S: OpenID4VPRelyingPartyState, httpClient: { get: (url: string, options?: Record<string, unknown>) => Promise<{ data: unknown }> }) => {
+export const retrieveKeys = async (S: OpenID4VPRelyingPartyState, httpClient: { get: (url: string, options?: Record<string, unknown>) => Promise<{ data: unknown }> }) => {
 	if (S.client_metadata.jwks) {
 		const rp_eph_pub_jwk = S.client_metadata.jwks.keys.filter((k) => k.use === "enc")[0];
 		if (!rp_eph_pub_jwk) {
 			throw new Error("Could not find Relying Party public key for encryption");
 		}
-		return { rp_eph_pub_jwk };
+		if (!rp_eph_pub_jwk.alg) {
+			throw new Error("alg is required in verifier's JWK");
+		}
+		return { rp_eph_pub_jwk, alg: rp_eph_pub_jwk.alg };
 	}
 	if (S.client_metadata.jwks_uri) {
 		const response = await httpClient.get(S.client_metadata.jwks_uri).catch(() => null);
@@ -130,7 +133,10 @@ const retrieveKeys = async (S: OpenID4VPRelyingPartyState, httpClient: { get: (u
 			if (!rp_eph_pub_jwk) {
 				throw new Error("Could not find Relying Party public key for encryption");
 			}
-			return { rp_eph_pub_jwk };
+			if (!rp_eph_pub_jwk.alg) {
+				throw new Error("alg is required in verifier's JWK");
+			}
+			return { rp_eph_pub_jwk, alg: rp_eph_pub_jwk.alg };
 		}
 	}
 	throw new Error("Could not find Relying Party public key for encryption");
@@ -555,12 +561,14 @@ export class OpenID4VPServerAPI<CredentialT extends OpenID4VPServerCredential, P
 
 		const formData = new URLSearchParams();
 
-		if ([OpenID4VPResponseMode.DIRECT_POST_JWT, OpenID4VPResponseMode.DC_API_JWT].includes(S.response_mode) && S.client_metadata.authorization_encrypted_response_alg) {
-			if (!S.client_metadata.authorization_encrypted_response_enc) {
-				throw new Error("Missing authorization_encrypted_response_enc");
+		if ([OpenID4VPResponseMode.DIRECT_POST_JWT, OpenID4VPResponseMode.DC_API_JWT].includes(S.response_mode)) {
+			let jweEnc = "A128GCM"; // TODO: use enum from wallet-common if available
+			if (S.client_metadata.encrypted_response_enc_values_supported) {
+				jweEnc = S.client_metadata.encrypted_response_enc_values_supported[0]; // TODO: check if supported by EncyptJWE first
 			}
-			const { rp_eph_pub_jwk } = await retrieveKeys(S, this.deps.httpClient);
-			const rp_eph_pub = await importJWK(rp_eph_pub_jwk, S.client_metadata.authorization_encrypted_response_alg);
+			const { rp_eph_pub_jwk, alg } = await retrieveKeys(S, this.deps.httpClient);
+			console.log("ALG=", alg);
+			const rp_eph_pub = await importJWK(rp_eph_pub_jwk, alg);
 
 			const jwePayload = {
 				vp_token: vpTokenObject,
@@ -570,8 +578,8 @@ export class OpenID4VPServerAPI<CredentialT extends OpenID4VPServerCredential, P
 			const jwe = await new EncryptJWT(jwePayload)
 				.setKeyManagementParameters({ apu: new TextEncoder().encode(apu), apv: new TextEncoder().encode(apv) })
 				.setProtectedHeader({
-					alg: S.client_metadata.authorization_encrypted_response_alg,
-					enc: S.client_metadata.authorization_encrypted_response_enc,
+					alg: alg,
+					enc: jweEnc,
 					kid: rp_eph_pub_jwk.kid,
 				})
 				.encrypt(rp_eph_pub);

--- a/src/protocols/openid4vp/types.ts
+++ b/src/protocols/openid4vp/types.ts
@@ -81,6 +81,12 @@ export enum OpenID4VPResponseMode {
 	DC_API_JWT = "dc_api.jwt",
 }
 
+export enum OpenID4VPJweEncryption {
+	A128GCM = "A128GCM",
+	A192GCM = "A192GCM",
+	A256GCM = "A256GCM",
+}
+
 export type OpenID4VPClientIdScheme = "x509_san_dns" | "x509_hash";
 
 export type OpenID4VPClientMetadata = {

--- a/src/protocols/openid4vp/types.ts
+++ b/src/protocols/openid4vp/types.ts
@@ -86,8 +86,7 @@ export type OpenID4VPClientIdScheme = "x509_san_dns" | "x509_hash";
 export type OpenID4VPClientMetadata = {
 	jwks?: { keys: any[] };
 	jwks_uri?: string;
-	authorization_encrypted_response_alg?: string;
-	authorization_encrypted_response_enc?: string;
+	encrypted_response_enc_values_supported?: string[];
 	vp_formats: any;
 };
 

--- a/src/utils/verifyX5C.test.ts
+++ b/src/utils/verifyX5C.test.ts
@@ -1,4 +1,4 @@
-import { assert, describe, expect, it } from "vitest";
+import { afterEach, assert, beforeEach, describe, it, vi } from "vitest";
 import { verifyX5C } from "./verifyX5C";
 
 // this x5c is signed by the first element in the trustedCertificates array
@@ -42,6 +42,16 @@ VPrJszACIHBsYf7toXfUFjr6y1nAJ/oXP9l/fWBDydcQIq+Vnfem
 
 
 describe("verifyX5C function", () => {
+	beforeEach(() => {
+		// Keep cert validity checks deterministic regardless of current date
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2025-10-01T00:00:00.000Z"));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	it("should verify successfully the chain", async () => {
 		const result = await verifyX5C(x5c, trustedCertificates);
 		assert(result === true);


### PR DESCRIPTION
This PR updates OpenID4VP response encryption handling in wallet-common to align encryption parameters with OID4VP 1.0.

What changed
* Added alg: "ECDH-ES" to generated RP ephemeral encryption JWK in the client flow.
* Replaced legacy client metadata fields (`authorization_encrypted_response_alg` / `authorization_encrypted_response_enc`) with `encrypted_response_enc_values_supported`.

In server response generation:
* Picks JWE enc from verifier-supported values when available.
* Falls back to A128GCM if no supported enc is provided.
* Uses encryption alg from the verifier JWK (`jwks` / `jwks_uri`).
* Strengthened key retrieval validation by requiring alg on the selected encryption JWK.