### PR TITLE
Fallback select best SD-JWT issuer metadata match by vct and claims

### DIFF
--- a/src/credential-parsers/SDJWTVCParser.test.ts
+++ b/src/credential-parsers/SDJWTVCParser.test.ts
@@ -119,6 +119,57 @@ describe("The SDJWTVCParser", () => {
 		assert(result.error === CredentialParsingError.InvalidSdJwtVcPayload);
 	});
 
+	it("should fallback to issuer metadata matched by vct when credentialIssuer is missing", async () => {
+		const httpClientWithIssuerMetadata: HttpClient = {
+			get: async (url: string, headers?: Record<string, unknown>, options?: any) => {
+				if (url.includes(".well-known/openid-credential-issuer")) {
+					return {
+						status: 200,
+						headers: {},
+						data: {
+							credential_issuer: "http://wallet-enterprise-issuer:8003",
+							credential_endpoint: "http://wallet-enterprise-issuer:8003/credential",
+							credential_configurations_supported: {
+								"pid_sd_jwt": {
+									format: "dc+sd-jwt",
+									scope: "pid_sd_jwt",
+									vct: "urn:eudi:pid:1",
+									credential_metadata: {
+										display: [
+											{
+												name: "PID via VCT fallback",
+												locale: "en-US",
+											},
+										],
+										claims: [
+											{
+												path: ["family_name"],
+												mandatory: true,
+												display: [{ name: "Family Name", locale: "en-US" }],
+											},
+										],
+									},
+								},
+							},
+						},
+					};
+				}
+				return defaultHttpClient.get(url, headers, options);
+			},
+			post: defaultHttpClient.post,
+		};
+
+		const parser = SDJWTVCParser({ httpClient: httpClientWithIssuerMetadata, context });
+		const result = await parser.parse({ rawCredential });
+		assert(result.success === true);
+
+		if (result.success) {
+			const credentialName = await result.value.metadata.credential.name(["en-US"]);
+			assert(credentialName === "PID via VCT fallback");
+			assert(result.value.metadata.credential.TypeMetadata.claims?.length === 1);
+		}
+	});
+
 	it("should warn if issuer metadata fetch fail", async () => {
 		const malformedHttpClient: HttpClient = {
 			get: async (url: string) => {

--- a/src/credential-parsers/SDJWTVCParser.test.ts
+++ b/src/credential-parsers/SDJWTVCParser.test.ts
@@ -119,7 +119,7 @@ describe("The SDJWTVCParser", () => {
 		assert(result.error === CredentialParsingError.InvalidSdJwtVcPayload);
 	});
 
-	it("should fallback to issuer metadata matched by vct when credentialIssuer is missing", async () => {
+	it("should fallback to the best issuer metadata matched by vct when credentialIssuer is missing", async () => {
 		const httpClientWithIssuerMetadata: HttpClient = {
 			get: async (url: string, headers?: Record<string, unknown>, options?: any) => {
 				if (url.includes(".well-known/openid-credential-issuer")) {
@@ -130,6 +130,26 @@ describe("The SDJWTVCParser", () => {
 							credential_issuer: "http://wallet-enterprise-issuer:8003",
 							credential_endpoint: "http://wallet-enterprise-issuer:8003/credential",
 							credential_configurations_supported: {
+								"generic_sd_jwt": {
+									format: "dc+sd-jwt",
+									scope: "generic_sd_jwt",
+									vct: "urn:eudi:pid:1",
+									credential_metadata: {
+										display: [
+											{
+												name: "Generic VCT match",
+												locale: "en-US",
+											},
+										],
+										claims: [
+											{
+												path: ["unmatched_claim"],
+												mandatory: true,
+												display: [{ name: "Unmatched Claim", locale: "en-US" }],
+											},
+										],
+									},
+								},
 								"pid_sd_jwt": {
 									format: "dc+sd-jwt",
 									scope: "pid_sd_jwt",

--- a/src/credential-parsers/SDJWTVCParser.ts
+++ b/src/credential-parsers/SDJWTVCParser.ts
@@ -15,6 +15,7 @@ import { dataUriResolver } from "../resolvers/dataUriResolver";
 import { friendlyNameResolver } from "../resolvers/friendlyNameResolver";
 import { fromBase64Url } from "../utils";
 import type { CredentialConfigurationSupported } from "../schemas/CredentialConfigurationSupportedSchema";
+import { findBestCredentialConfigurationByVct } from "../utils/findBestCredentialConfigurationByVct";
 
 export function SDJWTVCParser(args: { context: Context, httpClient: HttpClient }): CredentialParser {
 	const encoder = new TextEncoder();
@@ -151,9 +152,10 @@ export function SDJWTVCParser(args: { context: Context, httpClient: HttpClient }
 					: undefined;
 				if (metadataByConfigurationId) return metadataByConfigurationId;
 
-				// Fallback: if configuration id is missing/invalid, try matching by vct.
-				return Object.values(credentialConfigurationsSupported).find((configuration) =>
-					'vct' in configuration && configuration.vct === validatedParsedClaims.vct
+				return findBestCredentialConfigurationByVct(
+					credentialConfigurationsSupported,
+					validatedParsedClaims.vct,
+					validatedParsedClaims
 				);
 			})();
 

--- a/src/credential-parsers/SDJWTVCParser.ts
+++ b/src/credential-parsers/SDJWTVCParser.ts
@@ -14,6 +14,7 @@ import { convertOpenid4vciToSdjwtvcClaims } from "../functions/convertOpenid4vci
 import { dataUriResolver } from "../resolvers/dataUriResolver";
 import { friendlyNameResolver } from "../resolvers/friendlyNameResolver";
 import { fromBase64Url } from "../utils";
+import type { CredentialConfigurationSupported } from "../schemas/CredentialConfigurationSupportedSchema";
 
 export function SDJWTVCParser(args: { context: Context, httpClient: HttpClient }): CredentialParser {
 	const encoder = new TextEncoder();
@@ -140,9 +141,21 @@ export function SDJWTVCParser(args: { context: Context, httpClient: HttpClient }
 			let TypeMetadata: Partial<TypeMetadataSchema> = {};
 			let credentialMetadata: TypeMetadataSchema | undefined = undefined;
 
-			const credentialIssuerMetadata = credentialIssuer?.credentialConfigurationId
-				? issuerMetadata?.credential_configurations_supported?.[credentialIssuer?.credentialConfigurationId]
-				: undefined;
+			const credentialConfigurationsSupported =
+				issuerMetadata?.credential_configurations_supported as Record<string, CredentialConfigurationSupported> | undefined;
+			const credentialIssuerMetadata = (() => {
+				if (!credentialConfigurationsSupported) return undefined;
+
+				const metadataByConfigurationId = credentialIssuer?.credentialConfigurationId
+					? credentialConfigurationsSupported[credentialIssuer.credentialConfigurationId]
+					: undefined;
+				if (metadataByConfigurationId) return metadataByConfigurationId;
+
+				// Fallback: if configuration id is missing/invalid, try matching by vct.
+				return Object.values(credentialConfigurationsSupported).find((configuration) =>
+					'vct' in configuration && configuration.vct === validatedParsedClaims.vct
+				);
+			})();
 
 			if (getSdJwtMetadataResult.credentialMetadata) {
 

--- a/src/utils/findBestCredentialConfigurationByVct.ts
+++ b/src/utils/findBestCredentialConfigurationByVct.ts
@@ -1,0 +1,68 @@
+import type { CredentialConfigurationSupported } from "../schemas/CredentialConfigurationSupportedSchema";
+
+function hasClaimPath(payload: unknown, path: Array<string | number | null>, pathIndex = 0): boolean {
+	if (pathIndex >= path.length) return true;
+	if (payload === null || payload === undefined) return false;
+
+	const segment = path[pathIndex];
+	if (segment === null) {
+		return Array.isArray(payload)
+			? payload.some((item) => hasClaimPath(item, path, pathIndex + 1))
+			: false;
+	}
+
+	if (Array.isArray(payload)) {
+		return typeof segment === "number" && segment in payload
+			? hasClaimPath(payload[segment], path, pathIndex + 1)
+			: false;
+	}
+
+	if (typeof payload !== "object") return false;
+
+	const payloadRecord = payload as Record<string, unknown>;
+	const key = String(segment);
+	if (!Object.prototype.hasOwnProperty.call(payloadRecord, key)) return false;
+
+	return hasClaimPath(payloadRecord[key], path, pathIndex + 1);
+}
+
+function scoreCredentialConfigurationMatch(
+	configuration: CredentialConfigurationSupported,
+	payload: Record<string, unknown>,
+	payloadKeys: Set<string>
+): number {
+	return (configuration.credential_metadata?.claims ?? []).reduce((score, claim) => {
+		if (hasClaimPath(payload, claim.path)) return score + 2;
+
+		const topLevelKey = claim.path[0];
+		if (typeof topLevelKey === "string" && payloadKeys.has(topLevelKey)) return score + 1;
+
+		return score;
+	}, 0);
+}
+
+export function findBestCredentialConfigurationByVct(
+	credentialConfigurationsSupported: Record<string, CredentialConfigurationSupported>,
+	vct: string,
+	payload: Record<string, unknown>
+): CredentialConfigurationSupported | undefined {
+	const payloadKeys = new Set(Object.keys(payload));
+	const matches = Object.values(credentialConfigurationsSupported).filter((configuration) =>
+		'vct' in configuration && configuration.vct === vct
+	);
+
+	let bestMatch: CredentialConfigurationSupported | undefined;
+	let bestScore = -1;
+
+	for (const configuration of matches) {
+		const score = scoreCredentialConfigurationMatch(configuration, payload, payloadKeys);
+
+		// Keep the first match when scores tie, preserving issuer metadata order.
+		if (!bestMatch || score > bestScore) {
+			bestMatch = configuration;
+			bestScore = score;
+		}
+	}
+
+	return bestMatch;
+}


### PR DESCRIPTION
Adds a fallback for SD-JWT VC parsing when `credentialIssuer` is missing or its `credentialConfigurationId` cannot resolve issuer metadata.

### Changes

- Keeps direct `credentialConfigurationId` lookup as the first choice.
- Falls back to issuer credential configurations with the same `vct`.
- Selects the best match when multiple configurations share the same `vct` by comparing `validatedParsedClaims` against issuer metadata claim paths.
- Adds regression coverage for multiple matching `vct` configurations.