### PR TITLE
Use DCQL directly for OpenID4VP mdoc device response

### DIFF
--- a/src/protocols/openid4vp/OpenID4VPClientAPI.ts
+++ b/src/protocols/openid4vp/OpenID4VPClientAPI.ts
@@ -121,7 +121,7 @@ export class OpenID4VPClientAPI {
 			openid4vcRendering,
 			credentialRendering,
 		};
-}
+	}
 	async generateAuthorizationRequestURL(
 		presentationRequest: any,
 		sessionId: string,
@@ -267,7 +267,7 @@ export class OpenID4VPClientAPI {
 
 			date_created: Date.now(),
 			response_mode: responseMode,
-			};
+		};
 
 		await this.saveRPState(sessionId, newRpState);
 		await this.rpStateKV.set("key:" + exportedEphPub.kid, sessionId);
@@ -330,7 +330,7 @@ export class OpenID4VPClientAPI {
 								transaction_data_hashes_alg: (kbjwtPayload as any).transaction_data_hashes_alg as string[] | undefined
 							});
 							console.log("Message: ", message)
-							messages[descriptor.id] = [ message ];
+							messages[descriptor.id] = [message];
 							if (!status) {
 								return { error: new Error("transaction_data validation error") };
 							}
@@ -455,7 +455,16 @@ export class OpenID4VPClientAPI {
 						if (!claimsObject) {
 							return { error: new Error(`No claims found in mdoc for doctype ${descriptor.meta?.doctype_value}`) };
 						}
-						presentationClaims[descriptor.id] = Object.entries(claimsObject.valid_claim_sets[0].output[descriptor.meta?.doctype_value]).map(([key, value]) => ({
+						const outputByNamespace = claimsObject.valid_claim_sets?.[0]?.output as Record<string, Record<string, unknown>> | undefined;
+						const requestedNamespace = Array.isArray(descriptor?.claims)
+							? descriptor.claims.find((c: any) => Array.isArray(c?.path) && typeof c.path[0] === "string")?.path?.[0]
+							: undefined;
+						const namespaceKey = requestedNamespace
+							?? (outputByNamespace ? Object.keys(outputByNamespace)[0] : undefined);
+						if (!namespaceKey || !outputByNamespace?.[namespaceKey]) {
+							return { error: new Error(`No mdoc output namespace found for descriptor ${descriptor.id}`) };
+						}
+						presentationClaims[descriptor.id] = Object.entries(outputByNamespace[namespaceKey]).map(([key, value]) => ({
 							key,
 							name: key,
 							value: typeof value === 'object' ? JSON.stringify(value) : String(value),
@@ -575,7 +584,7 @@ export class OpenID4VPClientAPI {
 	}
 
 
-	public async handleResponseJARM(response: any, kid :string): Promise<Result<RPState, OpenID4VPClientError>> {
+	public async handleResponseJARM(response: any, kid: string): Promise<Result<RPState, OpenID4VPClientError>> {
 		// get rpstate only to get the private key to decrypt the response
 
 		const rpState = await this.getRPStateByKid(kid);
@@ -668,7 +677,7 @@ export class OpenID4VPClientAPI {
 		return ok(rpState);
 	}
 
-	public async getSignedRequestObject(sessionId: string): Promise<Result<string, OpenID4VPClientError>>{
+	public async getSignedRequestObject(sessionId: string): Promise<Result<string, OpenID4VPClientError>> {
 		const rpState = await this.getRPStateBySessionId(sessionId);
 
 		if (!rpState) {

--- a/src/protocols/openid4vp/OpenID4VPServerAPI.ts
+++ b/src/protocols/openid4vp/OpenID4VPServerAPI.ts
@@ -39,7 +39,8 @@ type OpenID4VPServerKeystore = {
 	): Promise<{ vpjwt: string }>;
 	generateDeviceResponse(
 		mdoc: any,
-		presentationDefinition: Record<string, unknown>,
+		dcqlQuery: Record<string, unknown>,
+		selectedCredentialId: string,
 		apu: string | undefined,
 		apv: string | undefined,
 		clientId: string,
@@ -128,12 +129,6 @@ function getSubtleCrypto(subtle?: SubtleCrypto): SubtleCrypto {
 	if (subtle) return subtle;
 	if (globalThis.crypto?.subtle) return globalThis.crypto.subtle;
 	throw new Error("Missing SubtleCrypto implementation");
-}
-
-function getRandomUUID(randomUUID?: () => string): string {
-	if (randomUUID) return randomUUID();
-	if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID();
-	return generateRandomIdentifier(16);
 }
 
 function getClientIdScheme(clientId: string): string {
@@ -344,40 +339,6 @@ export class OpenID4VPServerAPI<CredentialT extends OpenID4VPServerCredential, P
 		return { mapping, descriptorPurpose };
 	}
 
-	private convertDcqlToPresentationDefinition(dcql_query: any) {
-		const pdId = getRandomUUID(this.deps.randomUUID);
-		const input_descriptors = dcql_query.credentials.map((cred: any) => {
-			const descriptorId = cred.meta?.doctype_value;
-			const doctype = descriptorId ?? cred.claims?.[0]?.path?.[0];
-
-			const format: Record<string, any> = {};
-			if (cred.format === "mso_mdoc") {
-				format.mso_mdoc = { alg: ["ES256", "ES384", "EdDSA"] };
-			}
-
-			const fields = cred.claims.map((claim: any) => ({
-				path: [`$['${doctype}']${claim.path.slice(1).map((p: string) => `['${p}']`).join("")}`],
-				intent_to_retain: claim.intent_to_retain ?? false,
-			}));
-
-			return {
-				id: descriptorId,
-				format,
-				constraints: {
-					limit_disclosure: "required",
-					fields,
-				},
-			};
-		});
-
-		return {
-			id: pdId,
-			name: "DCQL-converted Presentation Definition",
-			purpose: dcql_query.credential_sets?.[0]?.purpose ?? "No purpose defined",
-			input_descriptors,
-		};
-	}
-
 	private generatePresentationFrameForDCQLPaths(paths: string[][]): any {
 		const frame: Record<string, any> = {};
 
@@ -522,44 +483,45 @@ export class OpenID4VPServerAPI<CredentialT extends OpenID4VPServerCredential, P
 
 				generatedVPs.push(vpjwt);
 				originalVCs.push(credential);
-				} else if (credential.format === VerifiableCredentialFormat.MSO_MDOC) {
-					const descriptor = (dcql_query as any).credentials.find((c: any) => c.id === selectionKey);
-					if (!descriptor) {
-						throw new Error(`No DCQL descriptor for id ${selectionKey}`);
-					}
-					const descriptorId = descriptor.meta?.doctype_value;
-					const { issuerSigned, docType, namespaceClaims } = decodeIssuerSignedCredential(credential.data);
-					const effectiveDocType = descriptorId ?? docType;
-					const mdoc = {
-						documents: [
-							{
-								docType: effectiveDocType,
-								issuerSigned,
-							},
-						],
-					};
-					const mdocGeneratedNonce = generateRandomIdentifier(8);
-					apu = mdocGeneratedNonce;
-					apv = nonce;
+			} else if (credential.format === VerifiableCredentialFormat.MSO_MDOC) {
+				const descriptor = (dcql_query as any).credentials.find((c: any) => c.id === selectionKey);
+				if (!descriptor) {
+					throw new Error(`No DCQL descriptor for id ${selectionKey}`);
+				}
+				const descriptorId = descriptor.meta?.doctype_value;
+				const { issuerSigned, docType, namespaceName, namespaceClaims } = decodeIssuerSignedCredential(credential.data);
+				const effectiveDocType = descriptorId ?? docType;
+				const mdoc = {
+					documents: [
+						{
+							docType: effectiveDocType,
+							issuerSigned,
+						},
+					],
+				};
+				const mdocGeneratedNonce = generateRandomIdentifier(8);
+				apu = mdocGeneratedNonce;
+				apv = nonce;
 
-					let dcqlQueryWithClaims: any;
-					if (!descriptor.claims || descriptor.claims.length === 0) {
-						dcqlQueryWithClaims = JSON.parse(JSON.stringify(dcql_query));
-						const descriptorIndex = dcqlQueryWithClaims.credentials.findIndex((c: any) => c.id === selectionKey);
-						if (descriptorIndex !== -1) {
-							dcqlQueryWithClaims.credentials[descriptorIndex].claims = Object.keys(namespaceClaims).map((key) => ({
-								id: key,
-								path: [effectiveDocType, key],
-							}));
-						}
-					} else {
-						dcqlQueryWithClaims = dcql_query;
+				let dcqlQueryWithClaims: any;
+				if (!descriptor.claims || descriptor.claims.length === 0) {
+					dcqlQueryWithClaims = JSON.parse(JSON.stringify(dcql_query));
+					const descriptorIndex = dcqlQueryWithClaims.credentials.findIndex((c: any) => c.id === selectionKey);
+					if (descriptorIndex !== -1) {
+						const namespaceForPaths = namespaceName ?? effectiveDocType;
+						dcqlQueryWithClaims.credentials[descriptorIndex].claims = Object.keys(namespaceClaims).map((key) => ({
+							id: key,
+							path: [namespaceForPaths, key],
+						}));
 					}
+				} else {
+					dcqlQueryWithClaims = dcql_query;
+				}
 
-				const presentationDefinition = this.convertDcqlToPresentationDefinition(dcqlQueryWithClaims);
 				const { deviceResponseMDoc } = await this.deps.keystore.generateDeviceResponse(
 					mdoc,
-					presentationDefinition,
+					dcqlQueryWithClaims,
+					selectionKey,
 					apu,
 					apv,
 					client_id,
@@ -629,11 +591,11 @@ export class OpenID4VPServerAPI<CredentialT extends OpenID4VPServerCredential, P
 		vcEntityList: CredentialT[]
 	): Promise<
 		| {
-				conformantCredentialsMap: Map<string, any>;
-				verifierDomainName: string;
-				verifierPurpose: string;
-				parsedTransactionData: ParsedTransactionDataT[] | null;
-			}
+			conformantCredentialsMap: Map<string, any>;
+			verifierDomainName: string;
+			verifierPurpose: string;
+			parsedTransactionData: ParsedTransactionDataT[] | null;
+		}
 		| { error: HandleAuthorizationRequestError }
 	> {
 		let {


### PR DESCRIPTION
Fixes an OpenID4VP mdoc assumption where `docType` and `namespace` were treated as the same in several places. 
This PR:
- preserves `docType` for descriptor metadata and uses the actual namespace for claim paths
- removes DCQL -> `presentation_definition` conversion
- generates device responses directly from DCQL + selected credential.

Result: correct claim extraction/interoperability when `namespace` != `docType` and fewer missing-claim failures.
