### PR TITLE
Handle MDOC CBOR Dates in formatDate

### DIFF
--- a/src/functions/formatDate.test.ts
+++ b/src/functions/formatDate.test.ts
@@ -139,4 +139,17 @@ describe("The Date/Time parser", () => {
 		assert(formattedDate != rawDate);
 	});
 
+	it("can match a CBOR Date object", async () => {
+		const cborDate = {
+			date: "14-08-2026"
+		};
+
+		const formattedDate = formatDate(cborDate);
+
+		console.log(cborDate);
+		console.log(formattedDate);
+
+		assert(formattedDate != cborDate);
+	});
+
 });

--- a/src/functions/formatDate.ts
+++ b/src/functions/formatDate.ts
@@ -1,3 +1,5 @@
+import { formatCborDate, isCborDate } from "../utils";
+
 export function formatDate(value: any, format = 'datetime') {
 	// Regex for ISO 8601 format like '2024-10-08T07:28:49.117Z'. milliseconds are optional.
 	const iso8601Regex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?Z$/;
@@ -38,6 +40,8 @@ export function formatDate(value: any, format = 'datetime') {
 	} else if (value instanceof Date) {
 		// Handle Date objects directly
 		date = value;
+	} else if (isCborDate(value)) {
+		return formatCborDate(value);
 	} else {
 		// For unsupported types, return the original value
 		return value;

--- a/src/utils/cborDate.test.ts
+++ b/src/utils/cborDate.test.ts
@@ -1,0 +1,64 @@
+import { assert, describe, it } from "vitest";
+import { formatCborDate, isCborDate } from "./cborDate";
+
+describe("isCborDate", () => {
+
+	it("can match a CBOR Date object", () => {
+		const cborDate = {
+			date: '01-01-2026'
+		};
+
+		assert(isCborDate(cborDate));
+	});
+
+	it("can match a CBOR Date object with additional fields", () => {
+		const cborDate = {
+			date: '01-01-2026',
+			approximate_mask: 'XXXXXXXX'
+		};
+
+		assert(isCborDate(cborDate));
+	});
+
+	it("does not match an object that is not a CBOR date", () => {
+		const randomObject = {
+			foo: 'bar'
+		};
+
+		assert(!isCborDate(randomObject));
+	});
+
+
+	it("does not match a simple date string", () => {
+		const dateString = "04-06-2026";
+
+		assert(!isCborDate(dateString));
+	});
+});
+
+describe("isCborDate", () => {
+
+	it("can format a CBOR Date object", () => {
+		const cborDate = {
+			date: '01-01-2026'
+		};
+
+		const formattedDate = formatCborDate(cborDate);
+		console.log(formattedDate);
+		assert(formattedDate === '01/01/2026');
+	});
+
+	it("does not alter an invalid CBOR object", () => {
+		const invalidCborDateObject = {
+			invalid_date: '01-01-2026',
+		};
+
+		const formattedDate = formatCborDate(invalidCborDateObject as any);
+
+		console.log(invalidCborDateObject);
+		console.log(formattedDate);
+
+		assert(JSON.stringify(invalidCborDateObject) === JSON.stringify(formattedDate));
+	});
+
+});

--- a/src/utils/cborDate.ts
+++ b/src/utils/cborDate.ts
@@ -29,8 +29,16 @@ export const isCborDate = (value: unknown): value is CborDateWrapper => {
 export const formatCborDate = (
 	value: CborDateWrapper,
 	locales: string | string[] = 'en-GB',
-): string => {
+): string | object => {
+
+	if (value === undefined || value === null) {
+		return value;
+	};
+
 	const rawDate = value.date;
+	if (rawDate === undefined) {
+		return value;
+	}
 
 	const parsedDate =
 		rawDate instanceof Date

--- a/src/utils/cborDate.ts
+++ b/src/utils/cborDate.ts
@@ -1,0 +1,45 @@
+type CborDateWrapper = {
+	date: Date | string | number;
+};
+
+/**
+ * Detects CBOR tag 1004 date wrapper objects.
+ */
+export const isCborDate = (value: unknown): value is CborDateWrapper => {
+	if (typeof value !== 'object' || value === null) {
+		return false;
+	}
+
+	if (!('date' in value)) {
+		return false;
+	}
+
+	const dateValue = value.date;
+
+	return (
+		dateValue instanceof Date ||
+		typeof dateValue === 'string' ||
+		typeof dateValue === 'number'
+	);
+};
+
+/**
+ * Formats a CBOR date wrapper into a localized date string.
+ */
+export const formatCborDate = (
+	value: CborDateWrapper,
+	locales: string | string[] = 'en-GB',
+): string => {
+	const rawDate = value.date;
+
+	const parsedDate =
+		rawDate instanceof Date
+			? rawDate
+			: new Date(rawDate);
+
+	if (Number.isNaN(parsedDate.getTime())) {
+		return String(rawDate);
+	}
+
+	return parsedDate.toLocaleDateString(locales);
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,6 @@
 export { verifyX5C } from './verifyX5C';
 export { getSdJwtVcMetadata } from './getSdJwtVcMetadata';
 export { prependToPath } from './urlPathUtils';
+export * from './cborDate';
 export * from './sri';
 export * from './util';


### PR DESCRIPTION
This PR adds a number of utility functions regarding CBOR Date objects, used when rendering MDOC objects. Additionally, the existing formatDate function is extended to handle CBOR Date objects, and render/format the inner date.