### PR TITLE
Support MDOC birth_date object with approximate mask

### DIFF
--- a/src/functions/formatDate.ts
+++ b/src/functions/formatDate.ts
@@ -1,4 +1,4 @@
-import { formatCborDate, isCborDate } from "../utils";
+import { formatCborBirthDate, formatCborDate, isCborBirthDate, isCborDate } from "../utils";
 
 export function formatDate(value: any, format = 'datetime') {
 	// Regex for ISO 8601 format like '2024-10-08T07:28:49.117Z'. milliseconds are optional.
@@ -42,6 +42,8 @@ export function formatDate(value: any, format = 'datetime') {
 		date = value;
 	} else if (isCborDate(value)) {
 		return formatCborDate(value);
+	} else if (isCborBirthDate(value)) {
+		return formatCborBirthDate(value);
 	} else {
 		// For unsupported types, return the original value
 		return value;

--- a/src/utils/cborDate.test.ts
+++ b/src/utils/cborDate.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "vitest";
-import { formatCborDate, isCborDate } from "./cborDate";
+import { formatCborBirthDate, formatCborDate, isCborBirthDate, isCborDate } from "./cborDate";
 
 describe("isCborDate", () => {
 
@@ -36,7 +36,7 @@ describe("isCborDate", () => {
 	});
 });
 
-describe("isCborDate", () => {
+describe("formatCborDate", () => {
 
 	it("can format a CBOR Date object", () => {
 		const cborDate = {
@@ -59,6 +59,74 @@ describe("isCborDate", () => {
 		console.log(formattedDate);
 
 		assert(JSON.stringify(invalidCborDateObject) === JSON.stringify(formattedDate));
+	});
+
+});
+
+describe("isCborBirthDate", () => {
+
+	it("can match a CBOR Birth Date object", () => {
+		const cborBirthDate = {
+			birth_date: {
+				date: '01-01-2026'
+			}
+		};
+
+		assert(isCborBirthDate(cborBirthDate));
+	});
+
+	it("can match a CBOR Birth Date object including approximate_mask", () => {
+		const cborBirthDate = {
+			birth_date: {
+				date: '01-01-2026'
+			},
+			approximate_mask: 'XXXXXXXX'
+		};
+
+		assert(isCborBirthDate(cborBirthDate));
+	});
+
+	it("does not match an object that is not a CBOR birth date", () => {
+		const randomObject = {
+			date: 'bar'
+		};
+
+		assert(!isCborBirthDate(randomObject));
+	});
+
+
+	it("does not match a simple date string", () => {
+		const dateString = "04-06-2026";
+
+		assert(!isCborBirthDate(dateString));
+	});
+});
+
+describe("formatCborBirthDate", () => {
+
+	it("can format a CBOR Birth Date object", () => {
+		const cborBirthDate = {
+			birth_date: {
+				date: '01-01-2026'
+			}
+		};
+
+		const formattedDate = formatCborBirthDate(cborBirthDate);
+		console.log(formattedDate);
+		assert(formattedDate === '01/01/2026');
+	});
+
+	it("does not alter an invalid CBOR object", () => {
+		const invalidCborBirthDateObject = {
+			invalid_date: '01-01-2026',
+		};
+
+		const formattedDate = formatCborBirthDate(invalidCborBirthDateObject as any);
+
+		console.log(invalidCborBirthDateObject);
+		console.log(formattedDate);
+
+		assert(JSON.stringify(invalidCborBirthDateObject) === JSON.stringify(formattedDate));
 	});
 
 });

--- a/src/utils/cborDate.ts
+++ b/src/utils/cborDate.ts
@@ -2,6 +2,11 @@ type CborDateWrapper = {
 	date: Date | string | number;
 };
 
+type CborBirthDateWrapper = {
+	birth_date: CborDateWrapper;
+	approximate_mask?: string;
+};
+
 /**
  * Detects CBOR tag 1004 date wrapper objects.
  */
@@ -21,6 +26,26 @@ export const isCborDate = (value: unknown): value is CborDateWrapper => {
 		typeof dateValue === 'string' ||
 		typeof dateValue === 'number'
 	);
+};
+
+export const isCborBirthDate = (value: unknown): value is CborBirthDateWrapper => {
+	if (typeof value !== 'object' || value === null) {
+		return false;
+	}
+
+	if (!('birth_date' in value)) {
+		return false;
+	}
+
+	if (Object.keys(value).length > 2) {
+		return false;
+	}
+
+	if (('approximate_mask' in value) && typeof value['approximate_mask'] !== 'string') {
+		return false;
+	}
+
+	return isCborDate(value.birth_date);
 };
 
 /**
@@ -50,4 +75,20 @@ export const formatCborDate = (
 	}
 
 	return parsedDate.toLocaleDateString(locales);
+};
+
+
+/**
+ * Formats a CBOR date wrapper into a localized date string.
+ */
+export const formatCborBirthDate = (
+	value: CborBirthDateWrapper,
+	locales: string | string[] = 'en-GB',
+): string | object => {
+
+	if (value === undefined || value === null || value.birth_date === undefined) {
+		return value;
+	};
+
+	return formatCborDate(value.birth_date, locales);
 };


### PR DESCRIPTION
This is the birth_date structure for MDOC (ISO/IEC 23220). It is not the case for MDL, as that uses CBOR Date (1004).

<img width="1158" height="414" alt="image" src="https://github.com/user-attachments/assets/504d9fbf-3b51-433b-8662-9b3f987f5208" />
