### PR TITLE
Replace vp_formats with vp_formats_supported in OID4VP client metadata

### DIFF
--- a/src/protocols/openid4vp/OpenID4VPClientAPI.ts
+++ b/src/protocols/openid4vp/OpenID4VPClientAPI.ts
@@ -198,7 +198,7 @@ export class OpenID4VPClientAPI {
 					]
 				},
 				"encrypted_response_enc_values_supported": ["A256GCM"],
-				"vp_formats": {
+				"vp_formats_supported": {
 					"vc+sd-jwt": {
 						"sd-jwt_alg_values": [
 							"ES256",

--- a/src/protocols/openid4vp/OpenID4VPServerAPI.test.ts
+++ b/src/protocols/openid4vp/OpenID4VPServerAPI.test.ts
@@ -86,7 +86,7 @@ const buildRequestUriJwt = async (clientId: string, dcqlQuery: Record<string, un
 		response_uri: "https://verifier.example.com/cb",
 		state: "state-hash",
 		nonce: "nonce-hash",
-		client_metadata: { vp_formats: {} },
+		client_metadata: { vp_formats_supported: {} },
 		response_mode: OpenID4VPResponseMode.DIRECT_POST,
 		dcql_query: dcqlQuery,
 	})
@@ -152,7 +152,7 @@ describe("OpenID4VPServerAPI.handleAuthorizationRequest", () => {
 		url.searchParams.set("response_uri", "https://verifier.example.com/cb");
 		url.searchParams.set("nonce", "nonce-123");
 		url.searchParams.set("state", "state-123");
-		url.searchParams.set("client_metadata", JSON.stringify({ vp_formats: {} }));
+		url.searchParams.set("client_metadata", JSON.stringify({ vp_formats_supported: {} }));
 		url.searchParams.set("response_mode", JSON.stringify(OpenID4VPResponseMode.DIRECT_POST));
 		url.searchParams.set("dcql_query", JSON.stringify(dcql_query));
 
@@ -215,7 +215,7 @@ describe("OpenID4VPServerAPI.handleAuthorizationRequest", () => {
 		url.searchParams.set("response_uri", "https://verifier.example.com/cb");
 		url.searchParams.set("nonce", "nonce-456");
 		url.searchParams.set("state", "state-456");
-		url.searchParams.set("client_metadata", JSON.stringify({ vp_formats: {} }));
+		url.searchParams.set("client_metadata", JSON.stringify({ vp_formats_supported: {} }));
 		url.searchParams.set("response_mode", JSON.stringify(OpenID4VPResponseMode.DIRECT_POST));
 		url.searchParams.set("dcql_query", JSON.stringify(dcql_query));
 
@@ -269,7 +269,7 @@ describe("OpenID4VPServerAPI.handleAuthorizationRequest", () => {
 		url.searchParams.set("response_uri", "https://verifier.example.com/cb");
 		url.searchParams.set("nonce", "nonce-789");
 		url.searchParams.set("state", "state-789");
-		url.searchParams.set("client_metadata", JSON.stringify({ vp_formats: {} }));
+		url.searchParams.set("client_metadata", JSON.stringify({ vp_formats_supported: {} }));
 		url.searchParams.set("response_mode", JSON.stringify(OpenID4VPResponseMode.DIRECT_POST));
 		url.searchParams.set("dcql_query", JSON.stringify(dcql_query));
 
@@ -307,7 +307,7 @@ describe("OpenID4VPServerAPI.handleAuthorizationRequest", () => {
 		url.searchParams.set("response_uri", "https://verifier.example.com/cb");
 		url.searchParams.set("nonce", "nonce-000");
 		url.searchParams.set("state", "state-000");
-		url.searchParams.set("client_metadata", JSON.stringify({ vp_formats: {} }));
+		url.searchParams.set("client_metadata", JSON.stringify({ vp_formats_supported: {} }));
 		url.searchParams.set("response_mode", JSON.stringify(OpenID4VPResponseMode.DIRECT_POST));
 
 		const result = await helper.handleAuthorizationRequest(url.toString(), []);
@@ -350,7 +350,7 @@ describe("OpenID4VPServerAPI.handleAuthorizationRequest", () => {
 		url.searchParams.set("response_uri", "https://verifier.example.com/cb");
 		url.searchParams.set("nonce", "nonce-001");
 		url.searchParams.set("state", "state-001");
-		url.searchParams.set("client_metadata", JSON.stringify({ vp_formats: {} }));
+		url.searchParams.set("client_metadata", JSON.stringify({ vp_formats_supported: {} }));
 		url.searchParams.set("response_mode", JSON.stringify(OpenID4VPResponseMode.DIRECT_POST));
 		url.searchParams.set("dcql_query", JSON.stringify(dcql_query));
 
@@ -398,7 +398,7 @@ describe("OpenID4VPServerAPI.handleAuthorizationRequest", () => {
 		url.searchParams.set("response_uri", "https://verifier.example.com/cb");
 		url.searchParams.set("nonce", "nonce-reused");
 		url.searchParams.set("state", "state-002");
-		url.searchParams.set("client_metadata", JSON.stringify({ vp_formats: {} }));
+		url.searchParams.set("client_metadata", JSON.stringify({ vp_formats_supported: {} }));
 		url.searchParams.set("response_mode", JSON.stringify(OpenID4VPResponseMode.DIRECT_POST));
 		url.searchParams.set("dcql_query", JSON.stringify(dcql_query));
 
@@ -463,7 +463,7 @@ describe("OpenID4VPServerAPI.handleAuthorizationRequest", () => {
 		url.searchParams.set("response_uri", "https://verifier.example.com/cb");
 		url.searchParams.set("nonce", "nonce-hash");
 		url.searchParams.set("state", "state-hash");
-		url.searchParams.set("client_metadata", JSON.stringify({ vp_formats: {} }));
+		url.searchParams.set("client_metadata", JSON.stringify({ vp_formats_supported: {} }));
 		url.searchParams.set("response_mode", JSON.stringify(OpenID4VPResponseMode.DIRECT_POST));
 		url.searchParams.set("dcql_query", JSON.stringify(dcql_query));
 		url.searchParams.set("request_uri", "https://verifier.example.com/request-object");
@@ -493,7 +493,7 @@ describe("OpenID4VPServerAPI.createAuthorizationResponse", () => {
 					client_id: "x509_san_dns:verifier.example.com",
 					state: "state-jwe",
 					client_metadata: {
-						vp_formats: {},
+						vp_formats_supported: {},
 						...(encryptedResponseEncValuesSupported
 							? { encrypted_response_enc_values_supported: encryptedResponseEncValuesSupported }
 							: {}),

--- a/src/protocols/openid4vp/OpenID4VPServerAPI.ts
+++ b/src/protocols/openid4vp/OpenID4VPServerAPI.ts
@@ -725,7 +725,7 @@ export class OpenID4VPServerAPI<CredentialT extends OpenID4VPServerCredential, P
 			response_uri: response_uri ?? "",
 			client_id: client_id ?? "",
 			state: state ?? "",
-			client_metadata: client_metadata ?? { vp_formats: {} },
+			client_metadata: client_metadata ?? { vp_formats_supported: {} },
 			response_mode,
 			transaction_data: transaction_data ?? [],
 			dcql_query,

--- a/src/protocols/openid4vp/types.ts
+++ b/src/protocols/openid4vp/types.ts
@@ -1,4 +1,5 @@
 import type { JWK } from "jose";
+import { VpFormatsSupported } from "../../schemas";
 
 export type ClaimRecord = {
 	key: string;
@@ -94,7 +95,7 @@ export type OpenID4VPClientMetadata = {
 	jwks?: { keys: any[] };
 	jwks_uri?: string;
 	encrypted_response_enc_values_supported?: string[];
-	vp_formats: any;
+	vp_formats_supported: VpFormatsSupported;
 };
 
 export type OpenID4VPRelyingPartyState = {

--- a/src/schemas/OpenID4VPClientMetadataVpFormatsSupportedSchema.ts
+++ b/src/schemas/OpenID4VPClientMetadataVpFormatsSupportedSchema.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+export const JwtVcJsonSchema = z.object({
+	alg_values: z.array(z.string()),
+});
+
+export const LdpVcSchema = z.object({
+	proof_type_values: z.array(z.string()),
+	cryptosuite_values: z.array(z.string()),
+});
+
+export const MsoMdocSchema = z.object({
+	issuerauth_alg_values: z.array(z.number()),
+	deviceauth_alg_values: z.array(z.number()),
+});
+
+export const DcSdJwtSchema = z.object({
+	'sd-jwt_alg_values': z.array(z.string()),
+	'kb-jwt_alg_values': z.array(z.string()),
+});
+
+export const VpFormatsSupportedSchema = z.object({
+	jwt_vc_json: JwtVcJsonSchema.optional(),
+	ldp_vc: LdpVcSchema.optional(),
+	mso_mdoc: MsoMdocSchema.optional(),
+	'dc+sd-jwt': DcSdJwtSchema.optional(),
+});
+
+export type VpFormatsSupported = z.infer<typeof VpFormatsSupportedSchema>;

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -5,3 +5,4 @@ export * from './OpenidCredentialIssuerMetadataSchema';
 export * from './SdJwtVcPayloadSchema';
 export * from './SdJwtVcTypeMetadataSchema';
 export * from './MdocIacasResponseSchema';
+export * from './OpenID4VPClientMetadataVpFormatsSupportedSchema';


### PR DESCRIPTION
Also strongly typed vp_formats_supported (even for unsupported formats), according to [OID4VP 1.0 Appendix B](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#appendix-B)