### PR TITLE
Fix bug with maps not being sent in MSO_MDOC presentations

### DIFF
--- a/src/protocols/openid4vp/OpenID4VPClientAPI.test.ts
+++ b/src/protocols/openid4vp/OpenID4VPClientAPI.test.ts
@@ -1,10 +1,12 @@
-import { assert, describe, it } from "vitest";
+import { assert, describe, it, vi } from "vitest";
 import { MemoryStore } from "../../core/MemoryStore";
 import { OpenID4VPClientAPI } from "./OpenID4VPClientAPI";
 import { OpenID4VPResponseMode  } from "./types";
 import { generateKeyPair, exportPKCS8, exportJWK, CompactEncrypt } from "jose";
 import { fromBase64Url, toBase64Url } from "../../utils/util";
 import type { HttpClient } from "../../interfaces";
+import { VerifiableCredentialFormat } from "../../types";
+import { DcqlPresentationResult } from "dcql";
 
 const x5c = [
 	"MIICyzCCAnGgAwIBAgIULnrxux9sI34oqbby3M4lSKOs8owwCgYIKoZIzj0EAwIwPzELMAkGA1UEBhMCRVUxFTATBgNVBAoMDHd3V2FsbGV0Lm9yZzEZMBcGA1UEAwwQd3dXYWxsZXQgUm9vdCBDQTAeFw0yNTA0MjkxMDI5NTNaFw0yNjA0MjkxMDI5NTNaMEExCzAJBgNVBAYTAkVVMRUwEwYDVQQKDAx3d1dhbGxldC5vcmcxGzAZBgNVBAMMEmxvY2FsLnd3d2FsbGV0Lm9yZzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFVivGt53M4qEP06QT20BSlGiMIdzLLvG+b9fq/fHKM+NGT+a3snXiPwU7X7jrOFWxwyjZeean40+vx6Gy06VfqjggFHMIIBQzAdBgNVHQ4EFgQUM/A3FTQLjww5/9u01MX/SRyVqaUwHwYDVR0jBBgwFoAU0HGu3T+/Wqh3yNifz9sNd+HPBS4wDgYDVR0PAQH/BAQDAgeAMDIGA1UdEgQrMCmBEWluZm9Ad3d3YWxsZXQub3JnhhRodHRwczovL3d3d2FsbGV0Lm9yZzASBgNVHSUECzAJBgcogYxdBQECMAwGA1UdEwEB/wQCMAAwRAYDVR0fBD0wOzA5oDegNYYzaHR0cHM6Ly93d3dhbGxldC5vcmcvaWFjYS9jcmwvd3d3YWxsZXRfb3JnX2lhY2EuY3JsMFUGA1UdEQROMEyCEmxvY2FsLnd3d2FsbGV0Lm9yZ4IZbG9jYWwtaXNzdWVyLnd3d2FsbGV0Lm9yZ4IbbG9jYWwtdmVyaWZpZXIud3d3YWxsZXQub3JnMAoGCCqGSM49BAMCA0gAMEUCIQCQ8h+5krhO+f4woReDY1D7CaM6qCda3m814e6DLvOphAIgHQL+Wm7WFRwxgjzMLN37RojJGrZbF4OFChIkmm0uu5o="
@@ -27,6 +29,44 @@ const presentationRequest = {
 		]
 	}
 };
+
+describe("OpenID4VPClientAPI.validateDcqlVpToken", () => {
+
+	it("should serialize Map values when building presentation claim values", () => {
+		const kv = new MemoryStore<string, any>();
+		const httpClient: HttpClient = {
+			get: async () => {
+				throw new Error("unexpected http call");
+			}
+		};
+		const helper = new OpenID4VPClientAPI(
+			kv,
+			{
+				credentialEngineOptions: {
+					clockTolerance: 0,
+					subtle: crypto.subtle,
+					lang: "en",
+					trustedCertificates: [],
+					trustedCredentialIssuerIdentifiers: undefined
+				},
+				redirectUri: "openid4vp://cb"
+			},
+			httpClient
+		);
+
+		const result = (helper as any).calculatePresentationClaimValue(
+			new Map([
+				["given_name", "John"],
+				["family_name", "Doe"]
+			])
+		);
+
+		assert.equal(
+			result,
+			'{"given_name":"John","family_name":"Doe"}'
+		);
+	});
+});
 
 describe("OpenID4VPClientAPI.generateAuthorizationRequestURL", () => {
 	it("should build a valid URL, store rpState, and include DCQL in the request JWT", async () => {

--- a/src/protocols/openid4vp/OpenID4VPClientAPI.ts
+++ b/src/protocols/openid4vp/OpenID4VPClientAPI.ts
@@ -69,6 +69,16 @@ export class OpenID4VPClientAPI {
 		return bytes;
 	}
 
+	private calculatePresentationClaimValue = (value: unknown): string => {
+		const normalizedValue = value instanceof Map
+			? Object.fromEntries(value)
+			: value;
+
+		return typeof normalizedValue === 'object'
+			? JSON.stringify(normalizedValue)
+			: String(normalizedValue);
+	}
+
 	private async initializeCredentialEngine() {
 		console.log("Initializing credential engine...")
 
@@ -399,7 +409,7 @@ export class OpenID4VPClientAPI {
 						presentationClaims[descriptor.id] = Object.entries(filteredSource).map(([key, value]) => ({
 							key,
 							name: key,
-							value: typeof value === 'object' ? JSON.stringify(value) : String(value),
+							value: this.calculatePresentationClaimValue(value),
 						}));
 					} else {
 						return { error: new Error(`Unexpected credential_format for descriptor ${descriptor.id}`) };
@@ -467,7 +477,7 @@ export class OpenID4VPClientAPI {
 						presentationClaims[descriptor.id] = Object.entries(outputByNamespace[namespaceKey]).map(([key, value]) => ({
 							key,
 							name: key,
-							value: typeof value === 'object' ? JSON.stringify(value) : String(value),
+							value: this.calculatePresentationClaimValue(value),
 						}));
 					} else {
 						return { error: new Error(`Unexpected mdoc credential_format in output for descriptor ${descriptor.id}`) };


### PR DESCRIPTION
Previously, if a DCQL query in OID4VP returned a map entry, the result would be {}, due to JSON.stringify() not being able to handle maps.

Now, the map is converted to an object and therefore not lost.