### PR TITLE
Proritize A256GCM response encryption when available

### DIFF
--- a/src/protocols/openid4vp/OpenID4VPServerAPI.test.ts
+++ b/src/protocols/openid4vp/OpenID4VPServerAPI.test.ts
@@ -535,10 +535,23 @@ describe("OpenID4VPServerAPI.createAuthorizationResponse", () => {
 		return result.formData.get("response") as string;
 	};
 
-	it("uses the first supported verifier JWE enc value", async () => {
-		const jwe = await createJwtResponse(["unsupported", OpenID4VPJweEncryption.A256GCM]);
+	it("uses the strongest wallet-preferred verifier JWE enc value", async () => {
+		const jwe = await createJwtResponse([
+			OpenID4VPJweEncryption.A128GCM,
+			"unsupported",
+			OpenID4VPJweEncryption.A256GCM,
+		]);
 
 		assert(decodeJweProtectedHeader(jwe).enc === OpenID4VPJweEncryption.A256GCM);
+	});
+
+	it("uses the next strongest wallet-preferred JWE enc value when A256GCM is not supported", async () => {
+		const jwe = await createJwtResponse([
+			OpenID4VPJweEncryption.A128GCM,
+			OpenID4VPJweEncryption.A192GCM,
+		]);
+
+		assert(decodeJweProtectedHeader(jwe).enc === OpenID4VPJweEncryption.A192GCM);
 	});
 
 	it("throws when verifier JWE enc values are provided but unsupported", async () => {
@@ -551,10 +564,10 @@ describe("OpenID4VPServerAPI.createAuthorizationResponse", () => {
 		}
 	});
 
-	it("falls back to A128GCM when verifier JWE enc values are not provided", async () => {
+	it("falls back to A256GCM when verifier JWE enc values are not provided", async () => {
 		const jwe = await createJwtResponse();
 
-		assert(decodeJweProtectedHeader(jwe).enc === OpenID4VPJweEncryption.A128GCM);
+		assert(decodeJweProtectedHeader(jwe).enc === OpenID4VPJweEncryption.A256GCM);
 	});
 });
 

--- a/src/protocols/openid4vp/OpenID4VPServerAPI.ts
+++ b/src/protocols/openid4vp/OpenID4VPServerAPI.ts
@@ -81,7 +81,11 @@ const encoder = new TextEncoder();
 const certFromB64 = (certBase64: string) =>
 	`-----BEGIN CERTIFICATE-----\n${certBase64.match(/.{1,64}/g)?.join("\n")}\n-----END CERTIFICATE-----`;
 const supportedClientIdSchemes = new Set(["x509_san_dns", "x509_hash"]);
-const supportedJweEncryptions = new Set<string>(Object.values(OpenID4VPJweEncryption));
+const preferredJweEncryptions = [
+	OpenID4VPJweEncryption.A256GCM,
+	OpenID4VPJweEncryption.A192GCM,
+	OpenID4VPJweEncryption.A128GCM,
+];
 
 function decodeIssuerSignedCredential(credentialDataB64u: string): {
 	issuerSigned: IssuerSigned;
@@ -544,14 +548,14 @@ export class OpenID4VPServerAPI<CredentialT extends OpenID4VPServerCredential, P
 		if ([OpenID4VPResponseMode.DIRECT_POST_JWT, OpenID4VPResponseMode.DC_API_JWT].includes(S.response_mode)) {
 			let jweEnc: string;
 			if (S.client_metadata.encrypted_response_enc_values_supported) {
-				const firstSupportedEnc = S.client_metadata.encrypted_response_enc_values_supported.find(
-					(enc) => supportedJweEncryptions.has(enc));
-				if (!firstSupportedEnc) {
+				const bestSupportedEnc = preferredJweEncryptions.find(
+					(enc) => S.client_metadata.encrypted_response_enc_values_supported?.includes(enc));
+				if (!bestSupportedEnc) {
 					throw new Error("Could not find supported algorithm in encrypted_response_enc_values_supported");
 				}
-				jweEnc = firstSupportedEnc;
+				jweEnc = bestSupportedEnc;
 			} else {
-				jweEnc = OpenID4VPJweEncryption.A128GCM;
+				jweEnc = OpenID4VPJweEncryption.A256GCM;
 			}
 			const { rp_eph_pub_jwk, alg } = await retrieveKeys(S, this.deps.httpClient);
 			const rp_eph_pub = await importJWK(rp_eph_pub_jwk, alg);


### PR DESCRIPTION
This PR slightly modifies credential response encryption by sorting the available supported response encryption algorithms by strength. It always prioritizes A256GCM when available, as per [HAIP section 5](https://openid.net/specs/openid4vc-high-assurance-interoperability-profile-1_0-final.html#section-5-2.5), and alternatively chooses A192GCM over A128GCM, when both exist